### PR TITLE
Feature/global styles

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,3 +1,24 @@
+@font-face {
+  font-family: 'SF Pro Text';
+  src: url('../fonts/SF-Pro-Display-Light.otf') format('opentype');
+  font-weight: 300; /* Light */
+  font-style: normal;
+}
+
+@font-face {
+  font-family: 'SF Pro Text';
+  src: url('../fonts/SF-Pro-Display-Regular.otf') format('opentype');
+  font-weight: 400; /* Regular */
+  font-style: normal;
+}
+
+@font-face {
+  font-family: 'SF Pro Text';
+  src: url('../fonts/SF-Pro-Display-Semibold.otf') format('opentype');
+  font-weight: 600; /* Semi-bold */
+  font-style: normal;
+}
+
 :root {
   /* Main colors */
   --primary: #6F6CF6; /* Same as purple500 */
@@ -164,10 +185,15 @@ a {
   text-decoration: none;
 }
 
-/* Input Styles */
+.hidden {
+  display: none !important;
+}
+
+/* Input, Text Area, Select List Styles */
 input[type="text"],
 input[type="password"],
-textarea {
+textarea,
+select {
   width: 100%;
   padding: var(--spacing-sm); /* 1rem */
   font-size: var(--font-size-md); /* 1rem */
@@ -183,26 +209,48 @@ textarea {
 
 input[type="text"]:focus,
 input[type="password"]:focus,
-textarea:focus {
+textarea:focus,
+select:focus {
   border-color: var(--primary);
 }
 
 input[type="text"]::placeholder,
 input[type="password"]::placeholder,
-textarea::placeholder {
+textarea::placeholder,
+select::placeholder {
   color: var(--gray400);
 }
 
 input[type="text"]:disabled,
 input[type="password"]:disabled,
-textarea:disabled {
+textarea:disabled,
+select:disabled {
   background-color: var(--gray100);
   color: var(--gray300);
   cursor: not-allowed;
 }
 
-.hidden {
-  display: none !important;
+select {
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  font-family: var(--font-family-body);
+  position: relative;
+  background: none;
+  padding-right: 2rem;
+  color: var(--gray400);
+  background: url("data:image/svg+xml;charset=UTF-8,%3Csvg xmlns='http://www.w3.org/2000/svg' height='24px' viewBox='0 -960 960 960' width='24px' fill='%23757880'%3E%3Cpath d='M480-376q-5 0-10-1.5t-9-5.5L284-568q-7-7-7-18t7-18q7-7 18-7t18 7l160 160 160-160q7-7 18-7t18 7q7 7 7 18t-7 18L500-383q-4 4-9 5.5t-10 1.5Z'/%3E%3C/svg%3E") no-repeat right 0.5rem center;
+  background-size: 2rem;
+}
+
+/* Button Styles */
+button {
+  font-family: var(--font-family-body);
+  transition: all 0.2s;
+}
+
+button:focus {
+  outline: none;
 }
 
 /* Media Queries */


### PR DESCRIPTION
- added global selector style and button style
- moved @font-face declarations to the top
- added back font family variables to ensure all the texts use the same set of font family
- added back
`body,
input,
textarea,
select,
table,
button {
  font-family: var(--font-family-body); /* Primary font for body text */
}`
to ensure all the texts use the same set of font family
- moved
`.xs {
  font-size: var(--font-size-xs);
}

.sm {
  font-size: var(--font-size-sm);
}

.lg {
  font-size: var(--font-size-lg);
}

.xl {
  font-size: var(--font-size-xl);
}

.icon {
  font-family: 'SUIT', sans-serif;
}

.bold {
  font-family: 'SF Pro Display Semibold', sans-serif;
  font-weight: 600;
}

.light {
  font-family: 'SF Pro Display Light', sans-serif;
  font-weight: 300;
}`
to the global css section


