### PR TITLE
Team Order Setting Page

### DIFF
--- a/src/app/restaurants/[storeId]/page.tsx
+++ b/src/app/restaurants/[storeId]/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef, useState } from 'react';
 
-import { useParams, useSearchParams } from 'next/navigation';
+import { useParams, useRouter, useSearchParams } from 'next/navigation';
 import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
 import { getRestaurantInfo } from '@/services/restaurantService';
 import { getMenuInfo, getMenuList } from '@/services/menuService';
@@ -25,10 +25,11 @@ const HeaderContainer = styled.div`
 `;
 
 const MenuItemContainer = styled.div`
-  padding-bottom: 6.875rem;
+  padding-bottom: 120px;
 `;
 
 const StorePage = () => {
+  const router = useRouter();
   const searchParams = useSearchParams();
   const { storeId } = useParams();
   const [activeModal, setActiveModal] = useState<string | null>(null);
@@ -139,6 +140,11 @@ const StorePage = () => {
     setActiveModal('infoModal');
   };
 
+  const onButtonClick1 = () => {
+    if (context === 'leaderBefore')
+      router.push(`/teamOrderSetting/${storeId}?`);
+  };
+
   useEffect(() => {
     const contextParam = searchParams.get('context');
     setContext(contextParam);
@@ -202,6 +208,7 @@ const StorePage = () => {
               buttonText={
                 context === 'participant' ? '장바구니로 이동' : '모임 만들기'
               }
+              onButtonClick={onButtonClick1}
             />
           </div>
         )}

--- a/src/app/restaurants/[storeId]/page.tsx
+++ b/src/app/restaurants/[storeId]/page.tsx
@@ -243,8 +243,7 @@ const StorePage = () => {
               ? context
               : undefined
           }
-          // eslint-disable-next-line no-console
-          onButtonClick1={() => console.log('Button 1 clicked')}
+          onButtonClick1={onButtonClick1}
           onButtonClick2={closeModal}
           onClose={closeModal}
         />

--- a/src/app/teamOrder/[meetingId]/page.tsx
+++ b/src/app/teamOrder/[meetingId]/page.tsx
@@ -13,6 +13,7 @@ import { getTeamMenuInfo, getTeamMenuList } from '@/services/teamMenuService';
 import { getIndividualOrderInfo } from '@/services/individualOrderService';
 import { IndividualOrderType, TeamMenuType } from '@/types/coreTypes';
 import Loading from '@/app/loading';
+import Container from '@/styles/container';
 import Header from '@/components/layout/header';
 import MainImage from '@/components/meetings/mainImage';
 import MeetingStatus from '@/components/meetings/meetingStatus';
@@ -169,35 +170,37 @@ const TeamOrderPage = () => {
   if (isErrorMeeting) return <p>Error loading meeting data</p>;
 
   return (
-    <div>
+    <>
       <Header buttonLeft="back" text={meeting?.storeName} />
-      <MainImage
-        src={meeting?.images[0]?.url || '/path/to/placeholder/image.jpg'}
-        alt={meeting?.storeName || 'No image available'}
-      />
-      <MeetingStatus
-        headCountData={headCountData || null}
-        meeting={meeting}
-        remainingTime={remainingTime}
-      />
-      <MeetingInfo meeting={meeting} />
+      <Container>
+        <MainImage
+          src={meeting?.images[0]?.url || '/path/to/placeholder/image.jpg'}
+          alt={meeting?.storeName || 'No image available'}
+        />
+        <MeetingStatus
+          headCountData={headCountData || null}
+          meeting={meeting}
+          remainingTime={remainingTime}
+        />
+        <MeetingInfo meeting={meeting} />
 
-      {meeting?.purchaseType === '함께 식사' && (
-        <TeamOrderItems teamMenus={teamMenus || { pages: [] }} />
-      )}
+        {meeting?.purchaseType === '함께 식사' && (
+          <TeamOrderItems teamMenus={teamMenus || { pages: [] }} />
+        )}
 
-      <RemainingAmountText>
-        {remainingAmount > 0
-          ? `최소 주문 금액까지 ${formatCurrency(remainingAmount)} 남았어요!`
-          : '최소 주문 금액이 다 채워졌어요!'}
-      </RemainingAmountText>
+        <RemainingAmountText>
+          {remainingAmount > 0
+            ? `최소 주문 금액까지 ${formatCurrency(remainingAmount)} 남았어요!`
+            : '최소 주문 금액이 다 채워졌어요!'}
+        </RemainingAmountText>
+      </Container>
       <Footer
         type="button"
         buttonText="모임 참여하기"
         $padding="3rem 1.5rem 1.5rem"
         onButtonClick={handleClick}
       />
-    </div>
+    </>
   );
 };
 

--- a/src/app/teamOrderSetting/[storeId]/page.tsx
+++ b/src/app/teamOrderSetting/[storeId]/page.tsx
@@ -2,28 +2,27 @@
 
 import { useState } from 'react';
 
-import { useParams } from 'next/navigation';
+import { useParams, useRouter } from 'next/navigation';
 import { useQuery } from '@tanstack/react-query';
 import { getRestaurantInfo } from '@/services/restaurantService';
 import { RestaurantType } from '@/types/coreTypes';
+import Container from '@/styles/container';
 import Header from '@/components/layout/header';
 import Step1 from '@/app/teamOrderSetting/[storeId]/step1';
 import Step2 from '@/app/teamOrderSetting/[storeId]/step2';
 import Footer from '@/components/layout/footer';
 import styled from 'styled-components';
-import router from 'next/router';
 
-const HeaderContainer = styled.div`
-  width: 100%;
-  header {
-    background-color: transparent;
-    box-shadow: none;
-    position: static;
-    z-index: auto;
-  }
+const CustomContainer = styled(Container)`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  padding: 0 var(--spacing-md) 6rem;
 `;
 
 const TeamOrderSettingPage = () => {
+  const router = useRouter();
   const { storeId } = useParams();
   const [currentStep, setCurrentStep] = useState(1);
 
@@ -35,33 +34,40 @@ const TeamOrderSettingPage = () => {
 
   const handleNextStep = () => {
     if (currentStep === 2) {
-      router.push('/nextPage');
+      router.push(`/restaurants/${storeId}?context=leaderBefore`);
     } else {
       setCurrentStep((prevStep) => prevStep + 1);
     }
   };
 
   const handleBackStep = () => {
-    if (currentStep > 1) {
+    if (currentStep === 1) {
+      router.push(`/restaurants/${storeId}?context=leaderBefore`);
+    } else if (currentStep > 1) {
       setCurrentStep((prevStep) => prevStep - 1);
     }
   };
 
   return (
-    <div>
-      <HeaderContainer>
-        <Header buttonLeft="back" buttonRight="exit" onBack={handleBackStep} />
-      </HeaderContainer>
-
-      {currentStep === 1 && <Step1 />}
-      {currentStep === 2 && <Step2 />}
-
-      <Footer
-        type="button"
-        buttonText={currentStep === 2 ? '설정 마무리하고 주문하기' : '다음으로'}
-        onButtonClick={handleNextStep}
+    <>
+      <Header
+        buttonLeft="back"
+        buttonRight="exit"
+        onBack={handleBackStep}
+        text="모임 만들기"
       />
-    </div>
+      <CustomContainer>
+        {currentStep === 1 && <Step1 />}
+        {currentStep === 2 && <Step2 />}
+        <Footer
+          type="button"
+          buttonText={
+            currentStep === 2 ? '설정 마무리하고 주문하기' : '다음으로'
+          }
+          onButtonClick={handleNextStep}
+        />
+      </CustomContainer>
+    </>
   );
 };
 

--- a/src/app/teamOrderSetting/[storeId]/page.tsx
+++ b/src/app/teamOrderSetting/[storeId]/page.tsx
@@ -1,11 +1,13 @@
 'use client';
 
 import { useState } from 'react';
+// import axios from 'axios';
 
 import { useParams, useRouter } from 'next/navigation';
 import { useQuery } from '@tanstack/react-query';
 import { getRestaurantInfo } from '@/services/restaurantService';
 import { RestaurantType } from '@/types/coreTypes';
+// import { useOrderStore } from '@/state/orderStore';
 import Container from '@/styles/container';
 import Header from '@/components/layout/header';
 import Step1 from '@/app/teamOrderSetting/[storeId]/step1';
@@ -25,6 +27,8 @@ const TeamOrderSettingPage = () => {
   const router = useRouter();
   const { storeId } = useParams();
   const [currentStep, setCurrentStep] = useState(1);
+
+  // const { formData } = useOrderStore();
 
   useQuery<RestaurantType>({
     queryKey: ['storeInfo', storeId],
@@ -48,6 +52,35 @@ const TeamOrderSettingPage = () => {
     }
   };
 
+  // const handleSubmit = async () => {
+  //   const requestBody = {
+  //     storeId: Number(storeId),
+  //     purchaseType: formData.mealType,
+  //     minHeadcount: formData.minHeadcount,
+  //     maxHeadcount: formData.maxHeadcount,
+  //     isEarlyPaymentAvailable: formData.orderType === '예약 주문',
+  //     paymentAvailableAt: new Date(),
+  //     // deliveredAddress: {
+  //     //   deliveredPostal: formData.deliveredPostal,
+  //     //   deliveredStreetAddress: formData.deliveredStreetAddress,
+  //     //   deliveredDetailAddress: formData.deliveredDetailAddress,
+  //     // },
+  //     // metAddress: {
+  //     //   metPostal: formData.metPostal,
+  //     //   metStreetAddress: formData.metStreetAddress,
+  //     //   metDetailAddress: formData.metDetailAddress,
+  //     // },
+  //     description: formData.additionalInfo,
+  //   };
+
+  //   try {
+  //     const response = await axios.post('/api/team-order', requestBody);
+  //     router.push(`/restaurants/${storeId}?context=leaderAfter`);
+  //   } catch (error) {
+  //     console.error(error);
+  //   }
+  // };
+
   return (
     <>
       <Header
@@ -61,9 +94,7 @@ const TeamOrderSettingPage = () => {
         {currentStep === 2 && <Step2 />}
         <Footer
           type="button"
-          buttonText={
-            currentStep === 2 ? '설정 마무리하고 주문하기' : '다음으로'
-          }
+          buttonText={currentStep === 2 ? '설정 완료 · 주문하기' : '다음으로'}
           onButtonClick={handleNextStep}
         />
       </CustomContainer>

--- a/src/app/teamOrderSetting/[storeId]/step1.tsx
+++ b/src/app/teamOrderSetting/[storeId]/step1.tsx
@@ -13,15 +13,6 @@ import SettingAddress from '@/components/meetings/settingAddress';
 import TimeInput from '@/components/common/timeInput';
 import { CustomDropdown } from '@/components/common/dropdown';
 import InfoBox from '@/components/common/infoBox';
-import styled from 'styled-components';
-
-const Container = styled.div`
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  padding: 0 var(--spacing-md) 6rem;
-`;
 
 const Step1 = () => {
   const { formData, setMealType, setOrderType, setMeetingPlace, setTime } =
@@ -59,7 +50,7 @@ const Step1 = () => {
   });
 
   return (
-    <Container>
+    <>
       <SettingImage />
       <SettingLabel text="팀 주문 방식" />
       <CustomDropdown
@@ -143,7 +134,7 @@ const Step1 = () => {
       />
       <SettingLabel text="주문 대기 최대 기한" />
       <TimeInput onTimeChange={setTime} time={time} />
-    </Container>
+    </>
   );
 };
 

--- a/src/app/teamOrderSetting/[storeId]/step2.tsx
+++ b/src/app/teamOrderSetting/[storeId]/step2.tsx
@@ -9,16 +9,6 @@ import SettingLabel from '@/components/meetings/settingLabel';
 import SettingHeadcount from '@/components/meetings/settingHeadcount';
 import SettingDescription from '@/components/meetings/settingDescription';
 import DeliveryFees from '@/components/meetings/deliveryFee';
-import styled from 'styled-components';
-
-const Container = styled.div`
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  padding: 0 var(--spacing-md) 6rem;
-  margin-top: 60px;
-`;
 
 const Step2 = () => {
   const { formData, setMinHeadcount, setMaxHeadcount, setAdditionalInfo } =
@@ -44,7 +34,7 @@ const Step2 = () => {
     store.deliveryPrice / Math.max(maxHeadcount, 1);
 
   return (
-    <Container>
+    <>
       <SettingLabel text="인원 제한" />
       <SettingHeadcount
         text="본인 포함 최소 인원"
@@ -68,7 +58,7 @@ const Step2 = () => {
         maxIndividualDeliveryFee={maxIndividualDeliveryFee}
         minIndividualDeliveryFee={minIndividualDeliveryFee}
       />
-    </Container>
+    </>
   );
 };
 

--- a/src/components/common/timeInput.tsx
+++ b/src/components/common/timeInput.tsx
@@ -82,9 +82,14 @@ interface TimeInputProps {
   onTimeChange: (
     newTime: Partial<{ amPm: string; hour: string; minute: string }>,
   ) => void;
+  validateTime?: (time: string) => void;
 }
 
-const TimeInput: React.FC<TimeInputProps> = ({ time, onTimeChange }) => {
+const TimeInput: React.FC<TimeInputProps> = ({
+  time,
+  onTimeChange,
+  validateTime,
+}) => {
   const { amPm, hour, minute } = time;
 
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
@@ -98,13 +103,33 @@ const TimeInput: React.FC<TimeInputProps> = ({ time, onTimeChange }) => {
     setIsDropdownOpen((prev) => !prev);
   };
 
+  const handleTimeChange = (
+    newTime: Partial<{ amPm: string; hour: string; minute: string }>,
+  ) => {
+    const updatedTime = {
+      ...time,
+      ...newTime,
+    };
+    const formattedTime = `${
+      updatedTime.amPm === '오후' && updatedTime.hour !== '12'
+        ? (parseInt(updatedTime.hour, 10) + 12).toString().padStart(2, '0')
+        : updatedTime.hour
+    }:${updatedTime.minute}`;
+
+    onTimeChange(updatedTime);
+
+    if (validateTime) {
+      validateTime(formattedTime);
+    }
+  };
+
   return (
     <TimeInputContainer>
       <DropdownWrapper>
         <CustomDropdown
           options={amPmOptions}
           selectedValue={amPm}
-          onSelect={(value) => onTimeChange({ amPm: value ?? '오전' })}
+          onSelect={(value) => handleTimeChange({ amPm: value ?? '오전' })}
           isOpen={isDropdownOpen}
           onToggle={handleDropdownToggle}
           placeholder="오전/오후"
@@ -117,7 +142,7 @@ const TimeInput: React.FC<TimeInputProps> = ({ time, onTimeChange }) => {
           type="text"
           value={hour}
           placeholder="00"
-          onChange={(e) => onTimeChange({ hour: e.target.value })}
+          onChange={(e) => handleTimeChange({ hour: e.target.value })}
           maxLength={2}
         />
         <Divider>:</Divider>
@@ -125,7 +150,7 @@ const TimeInput: React.FC<TimeInputProps> = ({ time, onTimeChange }) => {
           type="text"
           value={minute}
           placeholder="00"
-          onChange={(e) => onTimeChange({ minute: e.target.value })}
+          onChange={(e) => handleTimeChange({ minute: e.target.value })}
           maxLength={2}
         />
       </InputGroup>

--- a/src/components/listItems/menuItem.tsx
+++ b/src/components/listItems/menuItem.tsx
@@ -20,7 +20,7 @@ const MenuListWrapper = styled.div`
   align-items: center;
   height: 6.3125rem; /* 101px */
   background-color: var(--background);
-  padding: var(--spacing-sm);
+  padding: var(--spacing-sm) var(--spacing-sm) 0;
 `;
 
 const TextWrapper = styled.div`

--- a/src/components/meetings/errorMessage.tsx
+++ b/src/components/meetings/errorMessage.tsx
@@ -1,0 +1,17 @@
+import styled from 'styled-components';
+
+const ErrorText = styled.div`
+  color: red;
+  font-size: var(--font-size-sm);
+  margin-top: var(--spacing-xs);
+`;
+
+interface ErrorMessageProps {
+  message: string;
+}
+
+const ErrorMessage: React.FC<ErrorMessageProps> = ({ message }) => {
+  return <ErrorText>{message}</ErrorText>;
+};
+
+export default ErrorMessage;

--- a/src/components/meetings/mainImage.tsx
+++ b/src/components/meetings/mainImage.tsx
@@ -6,7 +6,7 @@ const ImageContainer = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
-  margin-top: 80px;
+  margin-top: 30px;
 `;
 
 const ImageWrapper = styled.div`

--- a/src/components/meetings/settingImage.tsx
+++ b/src/components/meetings/settingImage.tsx
@@ -37,7 +37,7 @@ const ImageWrapper = styled.div`
 
 const SettingImage = () => (
   <Container>
-    <Title>결제 성공!</Title>
+    <Title>팀 주문 시작</Title>
     <SubTitle>팀 주문에 함께 할 모임원들을 초대해요</SubTitle>
     <ImageWrapper>
       <Image

--- a/src/components/meetings/teamOrderItems.tsx
+++ b/src/components/meetings/teamOrderItems.tsx
@@ -17,7 +17,6 @@ const MenuContainer = styled.div`
   display: flex;
   flex-direction: column;
   gap: var(--spacing-xs);
-  padding-bottom: 8rem;
 `;
 
 const MenuItemRow = styled.div`

--- a/src/types/coreTypes.ts
+++ b/src/types/coreTypes.ts
@@ -36,8 +36,8 @@ export interface RestaurantType extends CommonType {
   entrepreneur_id?: number;
   address?: Address;
   phoneNumber?: string;
-  openTime?: string;
-  closeTime?: string;
+  openTime: string;
+  closeTime: string;
   dayOfWeek?: string;
 }
 


### PR DESCRIPTION
## Related issue
`#79` 

## Result
https://github.com/user-attachments/assets/ac833589-555d-49e6-94fd-c158bbc67719

## Work list
- 팀 주문 설정 페이지 화면과 주요 기능 구현했습니다.
- 주문 대기 최대 기한은 가게 영업 시간 안에 한정되고, 그 외에 시간을 선택하면 안내문 나옵니다.
- 모임 최소인원과 최대인원도 설정했고, min값은 모임장 본인을 포함해서 1입니다 (counter로 0까지 줄일 수 없고, 초기 값은 1입니다).
- 추가설명에 글자수 제한도 설정했습니다.
- 배달비는 counter입력에 따라 바로 계산합니다.
- zustand로 상태 관리 하고 있고, step 1과 step 2 사이에 이동해도 refresh하지 않은 경우 입력된 데이터를 사라지지 않습니다.

## To-Do
- 주소 관련 부분 구현하기
- "작성 중인 내용이 있습니다. 정말 나가실 건가요?" 라는 안내 modal 구현하기
- backend 에게 전달하는 handle submit 구현하다가, 사실 메뉴 선택하고 결제해야 정말 모임을 생성되는 거여서 일단 주석 처리했습니다. 내일 다시 생각하겠습니다.

## Discussion
- 와이어프렘에는 header 없고 닫기 버튼만 있는데, 사용자가 두 페이지 사이 이동해야 돼서 header과 back 버튼 넣었습니다.
