### PR TITLE
Feature/my page

### DIFF
--- a/src/app/inquiry/forum/contact.tsx
+++ b/src/app/inquiry/forum/contact.tsx
@@ -6,6 +6,7 @@ import { Flex } from '@chakra-ui/react';
 import styled from 'styled-components';
 import SettingDescription from '@/components/meetings/settingDescription';
 import Image from 'next/image';
+import ImagePreviewComponent from './imagePreview';
 
 const Container = styled.div`
   text-align: left;
@@ -73,7 +74,7 @@ const InquiryContact = ({ setIsActive, onFormDataChange }: Prop) => {
   const [title, setTitle] = useState('');
   const [content, setContent] = useState('');
   const [selectedImages, setSelectedImages] = useState<File[]>([]);
-  const [imagePreviews, setImagePreviews] = useState<string[]>([]); // 이미지 URL 저장
+  const [imagePreviews, setImagePreviews] = useState<string[]>([]);
 
   useEffect(() => {
     if (title.trim() && content.trim()) {
@@ -160,17 +161,12 @@ const InquiryContact = ({ setIsActive, onFormDataChange }: Prop) => {
 
           <ImagePreviewContainer>
             {imagePreviews.map((preview, index) => (
-              <ImageWrapper key={index}>
-                <ImagePreview src={preview} alt={`preview-${index}`} />
-                <DeleteButton onClick={() => handleRemoveImage(index)}>
-                  <Image
-                    src="/remove.svg"
-                    width="20"
-                    height="20"
-                    alt="remove"
-                  />
-                </DeleteButton>
-              </ImageWrapper>
+              <ImagePreviewComponent
+                key={index}
+                src={preview}
+                alt={`preview-${index}`}
+                onRemove={() => handleRemoveImage(index)}
+              />
             ))}
           </ImagePreviewContainer>
         </Flex>

--- a/src/app/inquiry/forum/contact.tsx
+++ b/src/app/inquiry/forum/contact.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
+import { Flex } from '@chakra-ui/react';
 import styled from 'styled-components';
 import SettingDescription from '@/components/meetings/settingDescription';
 import Image from 'next/image';
@@ -21,7 +22,7 @@ const ContentContainer = styled.div`
   font-size: var(--font-size-xs);
 `;
 
-const AddPicBtn = styled.button`
+const AddPicBtn = styled.label`
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -30,15 +31,47 @@ const AddPicBtn = styled.button`
   height: 4.5rem;
   border: 2px dashed var(--gray300);
   border-radius: var(--border-radius-md);
+  cursor: pointer;
+  margin-right: 0.5rem;
+`;
+
+const ImagePreviewContainer = styled.div`
+  display: flex;
+  gap: 0.5rem;
+`;
+
+const ImageWrapper = styled.div`
+  position: relative;
+  width: 4.5rem;
+  height: 4.5rem;
+`;
+
+const DeleteButton = styled.button`
+  position: absolute;
+  top: 5px;
+  right: 5px;
+  background-color: transparent;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+`;
+
+const ImagePreview = styled.img`
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: var(--border-radius-md);
 `;
 
 interface Prop {
   setIsActive: (isButtonActive: boolean) => void;
+  onFormDataChange: (formData: FormData) => void;
 }
 
-const InquiryContact = ({ setIsActive }: Prop) => {
+const InquiryContact = ({ setIsActive, onFormDataChange }: Prop) => {
   const [title, setTitle] = useState('');
   const [content, setContent] = useState('');
+  const [selectedImages, setSelectedImages] = useState<File[]>([]);
 
   useEffect(() => {
     if (title.trim() && content.trim()) {
@@ -46,45 +79,95 @@ const InquiryContact = ({ setIsActive }: Prop) => {
     } else {
       setIsActive(false);
     }
-  }, [setIsActive, title, content]);
+
+    const formData = new FormData();
+    formData.append('title', title);
+    formData.append('content', content);
+
+    selectedImages.forEach((image, index) => {
+      formData.append(`image${index + 1}`, image);
+    });
+
+    onFormDataChange(formData);
+  }, [title, content, selectedImages, setIsActive, onFormDataChange]);
+
+  const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.target.files && e.target.files.length > 0) {
+      const files = Array.from(e.target.files);
+      setSelectedImages((prevImages) => [...prevImages, ...files].slice(0, 3));
+    }
+  };
+
+  const handleRemoveImage = (index: number) => {
+    setSelectedImages((prevImages) => prevImages.filter((_, i) => i !== index));
+  };
 
   return (
-    <>
-      <Container>
-        <div>
-          <p>휴일을 제외하고 하루 이내에 답변 드립니다.</p>
-          <p>답변이 오지 않으면 스팸 메일함을 확인해주세요.</p>
-        </div>
+    <Container>
+      <div>
+        <p>휴일을 제외하고 하루 이내에 답변 드립니다.</p>
+        <p>답변이 오지 않으면 스팸 메일함을 확인해주세요.</p>
+      </div>
 
-        <ContentContainer>
-          <span>문의 제목</span>
-          <input
-            type="text"
-            placeholder="제목을 입력해주세요"
-            value={title}
-            onChange={(e) => setTitle(e.target.value)}
-          />
-        </ContentContainer>
-        <ContentContainer>
-          <span>문의 내용</span>
-          <AddPicBtn>
+      <ContentContainer>
+        <span>문의 제목</span>
+        <input
+          type="text"
+          placeholder="제목을 입력해주세요"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+        />
+      </ContentContainer>
+
+      <ContentContainer>
+        <span>문의 내용</span>
+        <Flex>
+          <AddPicBtn htmlFor="imageUpload">
             <Image
               src="/camera.svg"
               alt="add pictures"
               width="36"
               height="36"
             />
-            <p>{`${0}/3`}</p>
+            <p>{`${selectedImages.length}/3`}</p>
           </AddPicBtn>
-          <SettingDescription
-            placeholder="문의 내용을 남겨주세요"
-            charLimit={1000}
-            value={content}
-            onValueChange={setContent}
+          <input
+            type="file"
+            id="imageUpload"
+            accept="image/*"
+            multiple
+            style={{ display: 'none' }}
+            onChange={handleImageChange}
           />
-        </ContentContainer>
-      </Container>
-    </>
+
+          <ImagePreviewContainer>
+            {selectedImages.map((image, index) => (
+              <ImageWrapper key={index}>
+                <ImagePreview
+                  src={URL.createObjectURL(image)}
+                  alt={`preview-${index}`}
+                />
+                <DeleteButton onClick={() => handleRemoveImage(index)}>
+                  <Image
+                    src={'/remove.svg'}
+                    width="20"
+                    height="20"
+                    alt="remove"
+                  />
+                </DeleteButton>
+              </ImageWrapper>
+            ))}
+          </ImagePreviewContainer>
+        </Flex>
+
+        <SettingDescription
+          placeholder="문의 내용을 남겨주세요"
+          charLimit={1000}
+          value={content}
+          onValueChange={setContent}
+        />
+      </ContentContainer>
+    </Container>
   );
 };
 

--- a/src/app/inquiry/forum/contact.tsx
+++ b/src/app/inquiry/forum/contact.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useEffect, useState } from 'react';
+
 import { Flex } from '@chakra-ui/react';
 import styled from 'styled-components';
 import SettingDescription from '@/components/meetings/settingDescription';
@@ -72,6 +73,7 @@ const InquiryContact = ({ setIsActive, onFormDataChange }: Prop) => {
   const [title, setTitle] = useState('');
   const [content, setContent] = useState('');
   const [selectedImages, setSelectedImages] = useState<File[]>([]);
+  const [imagePreviews, setImagePreviews] = useState<string[]>([]); // 이미지 URL 저장
 
   useEffect(() => {
     if (title.trim() && content.trim()) {
@@ -90,6 +92,22 @@ const InquiryContact = ({ setIsActive, onFormDataChange }: Prop) => {
 
     onFormDataChange(formData);
   }, [title, content, selectedImages, setIsActive, onFormDataChange]);
+
+  useEffect(() => {
+    // 이전에 생성된 URL 해제
+    imagePreviews.forEach((url) => URL.revokeObjectURL(url));
+
+    // 새로운 이미지 URL 생성
+    const newPreviews = selectedImages.map((image) =>
+      URL.createObjectURL(image),
+    );
+    setImagePreviews(newPreviews);
+
+    // 컴포넌트가 언마운트되거나 이미지가 변경될 때 URL 해제
+    return () => {
+      newPreviews.forEach((url) => URL.revokeObjectURL(url));
+    };
+  }, [selectedImages]);
 
   const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (e.target.files && e.target.files.length > 0) {
@@ -141,15 +159,12 @@ const InquiryContact = ({ setIsActive, onFormDataChange }: Prop) => {
           />
 
           <ImagePreviewContainer>
-            {selectedImages.map((image, index) => (
+            {imagePreviews.map((preview, index) => (
               <ImageWrapper key={index}>
-                <ImagePreview
-                  src={URL.createObjectURL(image)}
-                  alt={`preview-${index}`}
-                />
+                <ImagePreview src={preview} alt={`preview-${index}`} />
                 <DeleteButton onClick={() => handleRemoveImage(index)}>
                   <Image
-                    src={'/remove.svg'}
+                    src="/remove.svg"
                     width="20"
                     height="20"
                     alt="remove"

--- a/src/app/inquiry/forum/history.tsx
+++ b/src/app/inquiry/forum/history.tsx
@@ -1,16 +1,29 @@
 'use client';
 
 import { useEffect, useRef, useState } from 'react';
-import { ImageType } from '@/types/types';
 import InquirySkeleton from '@/components/listItems/skeletons/inquirySkeleton';
 import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
 import { getInquiries, getInquiryImages } from '@/services/myDataService';
 import { formatDateTime } from '@/utils/formateDateTime';
 import styled from 'styled-components';
-import { Divider, Flex, Skeleton } from '@chakra-ui/react';
+import {
+  Divider,
+  Flex,
+  Skeleton,
+  useDisclosure,
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalFooter,
+  ModalBody,
+  ModalCloseButton,
+} from '@chakra-ui/react';
 import Image from 'next/image';
+import axios from 'axios';
 
 import TriggerButton from './triggerButton';
+import InquiryImages from './inquiryImages';
 
 const Container = styled.div`
   text-align: left;
@@ -19,6 +32,13 @@ const Container = styled.div`
 
 const ContentContainer = styled.div`
   padding: 1rem;
+
+  span,
+  button {
+    font-size: var(--font-size-xs);
+    color: var(--gray300);
+    margin-bottom: 0.2rem;
+  }
 `;
 
 const AnswerContainer = styled.div`
@@ -49,6 +69,7 @@ const ImageWrapper = styled.div`
 `;
 
 const InquiryHistory = () => {
+  const { isOpen, onOpen, onClose } = useDisclosure();
   const observer = useRef<IntersectionObserver | null>(null);
   const lastElementRef = useRef<HTMLDivElement | null>(null);
   const [selectedInquiryId, setSelectedInquiryId] = useState<number | null>(
@@ -68,7 +89,7 @@ const InquiryHistory = () => {
   const {
     data: images,
     isLoading: isImagesLoading,
-    error: isImagesError,
+    isError: isImagesError,
   } = useQuery({
     queryKey: ['InquiryDetail', selectedInquiryId],
     queryFn: () => {
@@ -79,6 +100,10 @@ const InquiryHistory = () => {
     },
     enabled: selectedInquiryId !== null,
   });
+
+  // const handleModalExit = () => {
+  //   window.location.reload();
+  // };
 
   const handleItemClick = (inquiryId: number) => {
     setSelectedInquiryId((prev) => (prev === inquiryId ? null : inquiryId));
@@ -111,94 +136,98 @@ const InquiryHistory = () => {
   }, [isFetchingNextPage, hasNextPage, fetchNextPage]);
 
   return (
-    <Container>
-      {status === 'pending' ? (
-        <>
-          <InquirySkeleton />
-          <InquirySkeleton />
-          <InquirySkeleton />
-          <InquirySkeleton />
-          <InquirySkeleton />
-          <InquirySkeleton />
-          <InquirySkeleton />
-        </>
-      ) : status === 'error' ? (
-        <p>문의 내역을 불러오지 못했습니다.</p>
-      ) : data && data.pages.length > 0 ? (
-        <>
-          {data.pages.map((page) =>
-            page.content.map((item) => {
-              const { formattedFullDate } = formatDateTime(item.updatedAt);
+    <>
+      <Container>
+        {status === 'pending' ? (
+          <>
+            <InquirySkeleton />
+            <InquirySkeleton />
+            <InquirySkeleton />
+            <InquirySkeleton />
+            <InquirySkeleton />
+            <InquirySkeleton />
+            <InquirySkeleton />
+          </>
+        ) : status === 'error' ? (
+          <p>문의 내역을 불러오지 못했습니다.</p>
+        ) : data && data.pages.length > 0 ? (
+          <>
+            {data.pages.map((page) =>
+              page.content.map((item) => {
+                const { formattedFullDate } = formatDateTime(item.updatedAt);
 
-              return (
-                <div key={item.inquiryId}>
-                  <TriggerButton
-                    isSelected={selectedInquiryId === item.inquiryId}
-                    onClick={() => handleItemClick(item.inquiryId)}
-                    inquiry={item}
-                  />
-                  {selectedInquiryId === item.inquiryId && (
-                    <div>
-                      <ContentContainer>
-                        <ImagesContainer>
-                          {isImagesError ? (
-                            <>
-                              <ImageWrapper>{'no Image'}</ImageWrapper>
-                              <ImageWrapper>{'no Image'}</ImageWrapper>
-                              <ImageWrapper>{'no Image'}</ImageWrapper>
-                            </>
-                          ) : isImagesLoading ? (
-                            <>
-                              <ImageWrapper>
-                                <Skeleton w="100px" h="100px" />
-                              </ImageWrapper>
-                              <ImageWrapper>
-                                <Skeleton w="100px" h="100px" />
-                              </ImageWrapper>
-                              <ImageWrapper>
-                                <Skeleton w="100px" h="100px" />
-                              </ImageWrapper>
-                            </>
-                          ) : (
-                            images &&
-                            images.map((item: ImageType) => (
-                              <ImageWrapper key={item.imageId}>
-                                <Image
-                                  src={item.url}
-                                  alt={`${item.sequence}번 째 이미지`}
-                                  fill
-                                  style={{ objectFit: 'cover' }}
-                                  priority
-                                />
-                              </ImageWrapper>
-                            ))
-                          )}
-                        </ImagesContainer>
-                        <div>{item.content}</div>
-                      </ContentContainer>
-                      {item.status === 'COMPLETED' && (
-                        <AnswerContainer>
+                return (
+                  <div key={item.inquiryId}>
+                    <TriggerButton
+                      isSelected={selectedInquiryId === item.inquiryId}
+                      onClick={() => handleItemClick(item.inquiryId)}
+                      inquiry={item}
+                    />
+
+                    {selectedInquiryId === item.inquiryId && (
+                      <div>
+                        <ContentContainer>
                           <Flex h="4" gap="2" mb="2">
-                            <span>답변내용</span>
-                            <Divider orientation="vertical" />
-                            <span>{formattedFullDate}</span>
+                            <span>문의내용</span>
+
+                            {item.status === 'PENDING' && (
+                              <>
+                                <Divider orientation="vertical" />
+                                <button onClick={onOpen}>수정하기</button>
+                              </>
+                            )}
                           </Flex>
-                          <div>{item.answer}</div>
-                        </AnswerContainer>
-                      )}
-                    </div>
-                  )}
-                </div>
-              );
-            }),
-          )}
-        </>
-      ) : (
-        <div>문의 내역이 없습니다.</div>
-      )}
-      <div ref={lastElementRef}></div>
-    </Container>
+                          <ImagesContainer>
+                            <InquiryImages
+                              images={images}
+                              isLoading={isImagesLoading}
+                              isError={isImagesError}
+                            />
+                          </ImagesContainer>
+                          <div>{item.content}</div>
+                        </ContentContainer>
+
+                        {item.status === 'COMPLETED' && (
+                          <AnswerContainer>
+                            <Flex h="4" gap="2" mb="2">
+                              <span>답변내용</span>
+                              <Divider orientation="vertical" />
+                              <span>{formattedFullDate}</span>
+                            </Flex>
+                            <div>{item.answer}</div>
+                          </AnswerContainer>
+                        )}
+                      </div>
+                    )}
+                  </div>
+                );
+              }),
+            )}
+          </>
+        ) : (
+          <div>문의 내역이 없습니다.</div>
+        )}
+        <div ref={lastElementRef}></div>
+      </Container>
+
+      <Modal onClose={onClose} isOpen={isOpen} isCentered>
+        <ModalOverlay />
+        <ModalContent>
+          <ModalHeader>Modal Title</ModalHeader>
+          <ModalCloseButton />
+          <ModalBody>
+            <div>rmfwkrmfwkrmfkwrmfm</div>
+          </ModalBody>
+          <ModalFooter>
+            <button onClick={onClose}>Close</button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+    </>
   );
 };
 
 export default InquiryHistory;
+
+// onClick={handleModalContinue}
+// onClick={handleModalExit}

--- a/src/app/inquiry/forum/imagePreview.tsx
+++ b/src/app/inquiry/forum/imagePreview.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import styled from 'styled-components';
+import Image from 'next/image';
+
+const ImageWrapper = styled.div`
+  position: relative;
+  width: 4.5rem;
+  height: 4.5rem;
+`;
+
+const DeleteButton = styled.button`
+  position: absolute;
+  top: 5px;
+  right: 5px;
+  background-color: transparent;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+`;
+
+const ImagePreview = styled.img`
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: var(--border-radius-md);
+`;
+
+interface ImagePreviewProps {
+  src: string;
+  alt: string;
+  onRemove: () => void;
+}
+
+const ImagePreviewComponent: React.FC<ImagePreviewProps> = ({
+  src,
+  alt,
+  onRemove,
+}) => (
+  <ImageWrapper>
+    <ImagePreview src={src} alt={alt} />
+    <DeleteButton aria-label="이미지 삭제" onClick={onRemove}>
+      <Image src="/remove.svg" width="20" height="20" alt="remove" />
+    </DeleteButton>
+  </ImageWrapper>
+);
+
+export default ImagePreviewComponent;

--- a/src/app/inquiry/forum/inquiryImages.tsx
+++ b/src/app/inquiry/forum/inquiryImages.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import styled from 'styled-components';
+import Image from 'next/image';
+import { ImageType } from '@/types/types';
+import { Skeleton } from '@chakra-ui/react';
+
+const ImageWrapper = styled.div`
+  border-radius: var(--border-radius-md);
+  overflow: hidden;
+  background: var(--gray200);
+  position: relative;
+  width: 100px;
+  height: 100px;
+`;
+
+interface InquiryImagesProps {
+  images: ImageType[];
+  isLoading: boolean;
+  isError: boolean;
+}
+
+const InquiryImages: React.FC<InquiryImagesProps> = ({
+  images,
+  isLoading,
+  isError,
+}) => {
+  if (isError) {
+    return (
+      <>
+        <ImageWrapper>{'no Image'}</ImageWrapper>
+        <ImageWrapper>{'no Image'}</ImageWrapper>
+        <ImageWrapper>{'no Image'}</ImageWrapper>
+      </>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <>
+        <ImageWrapper>
+          <Skeleton w="100px" h="100px" />
+        </ImageWrapper>
+        <ImageWrapper>
+          <Skeleton w="100px" h="100px" />
+        </ImageWrapper>
+        <ImageWrapper>
+          <Skeleton w="100px" h="100px" />
+        </ImageWrapper>
+      </>
+    );
+  }
+
+  return (
+    <>
+      {images.map((item: ImageType) => (
+        <ImageWrapper key={item.imageId}>
+          <Image
+            src={item.url}
+            alt={`${item.sequence}번 째 이미지`}
+            fill
+            style={{ objectFit: 'cover' }}
+            priority
+          />
+        </ImageWrapper>
+      ))}
+    </>
+  );
+};
+
+export default InquiryImages;

--- a/src/app/inquiry/forum/page.tsx
+++ b/src/app/inquiry/forum/page.tsx
@@ -1,12 +1,14 @@
 'use client';
 
-import { useState, useEffect } from 'react';
-import { Tab, TabList, Tabs, TabPanel, TabPanels } from '@chakra-ui/react';
+import { useEffect, useState } from 'react';
+import axios from 'axios';
+
+import { Tab, TabList, TabPanel, TabPanels, Tabs } from '@chakra-ui/react';
 import Header from '@/components/layout/header';
 import Footer from '@/components/layout/footer';
 import Container from '@/styles/container';
 import { useRouter, useSearchParams } from 'next/navigation';
-import axios from 'axios';
+
 import InquiryContact from './contact';
 import InquiryHistory from './history';
 
@@ -25,18 +27,20 @@ const InquiryForum = () => {
     if (pageType) {
       router.replace(`/inquiry/forum/?type=${pageType}`, { scroll: false });
     }
-  }, [pageType, router]);
+  }, [pageType]);
 
   const onClickSubmitBtn = async () => {
     if (!formData) return;
 
     try {
-      await axios.post(`/api/users/inquires`, formData, {
-        headers: {
-          'Content-Type': 'multipart/form-data',
-        },
-      });
-      console.log(formData)
+      const config = formData.has('image1')
+        ? {
+            headers: { 'Content-Type': 'multipart/form-data' },
+          }
+        : {};
+
+      await axios.post(`/api/users/inquires`, formData, config);
+      console.log(formData);
       alert('문의가 접수되었습니다.');
       setPageType('history');
     } catch (error) {

--- a/src/app/inquiry/forum/page.tsx
+++ b/src/app/inquiry/forum/page.tsx
@@ -21,7 +21,7 @@ const InquiryForum = () => {
     initialType === 'history' ? 'history' : 'contact',
   );
   const [isButtonActive, setIsActive] = useState(false);
-  const [formData, setFormData] = useState<FormData | null>(null); // FormData 상태 추가
+  const [formData, setFormData] = useState<FormData | null>(null);
 
   useEffect(() => {
     if (pageType) {
@@ -57,7 +57,8 @@ const InquiryForum = () => {
           position="fixed"
           w="100%"
           isFitted
-          aria-label="문의 내역, 문의 하기"
+          aria-label="문의 내역 및 문의 하기"
+          aria-labelledby="inquiry-tabs"
           bg="white"
           index={pageType === 'contact' ? 0 : 1}
           onChange={(index) => setPageType(index === 0 ? 'contact' : 'history')}

--- a/src/app/inquiry/forum/page.tsx
+++ b/src/app/inquiry/forum/page.tsx
@@ -1,11 +1,11 @@
 'use client';
 
+import { useState, useEffect } from 'react';
 import { Tab, TabList, Tabs, TabPanel, TabPanels } from '@chakra-ui/react';
 import Header from '@/components/layout/header';
 import Footer from '@/components/layout/footer';
 import Container from '@/styles/container';
 import { useRouter, useSearchParams } from 'next/navigation';
-import { useState, useEffect } from 'react';
 import axios from 'axios';
 import InquiryContact from './contact';
 import InquiryHistory from './history';
@@ -19,6 +19,7 @@ const InquiryForum = () => {
     initialType === 'history' ? 'history' : 'contact',
   );
   const [isButtonActive, setIsActive] = useState(false);
+  const [formData, setFormData] = useState<FormData | null>(null); // FormData 상태 추가
 
   useEffect(() => {
     if (pageType) {
@@ -27,8 +28,15 @@ const InquiryForum = () => {
   }, [pageType, router]);
 
   const onClickSubmitBtn = async () => {
+    if (!formData) return;
+
     try {
-      // await axios.post(`/api/users/inquiries`);
+      await axios.post(`/api/users/inquires`, formData, {
+        headers: {
+          'Content-Type': 'multipart/form-data',
+        },
+      });
+      console.log(formData)
       alert('문의가 접수되었습니다.');
       setPageType('history');
     } catch (error) {
@@ -58,7 +66,10 @@ const InquiryForum = () => {
             <TabPanel>
               {pageType === 'contact' && (
                 <>
-                  <InquiryContact setIsActive={setIsActive} />
+                  <InquiryContact
+                    setIsActive={setIsActive}
+                    onFormDataChange={setFormData}
+                  />
                   <Footer
                     type="button"
                     buttonText="문의하기"

--- a/src/app/inquiry/forum/triggerButton.tsx
+++ b/src/app/inquiry/forum/triggerButton.tsx
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 import { formatDateTime } from '@/utils/formateDateTime';
+import { InquiryType } from '@/types/myDataTypes';
 
 const TriggerButtonContainer = styled.div<{ $isSelected?: boolean }>`
   display: flex;
@@ -61,7 +62,7 @@ const TriggerButton = ({
   onClick,
   isSelected,
 }: {
-  inquiry: any;
+  inquiry: InquiryType;
   onClick: () => void;
   isSelected: boolean;
 }) => {

--- a/src/mocks/handlers/myDataHandler.js
+++ b/src/mocks/handlers/myDataHandler.js
@@ -10,8 +10,8 @@ import { evaluates, myData, paginatedPoints } from '../mockData/myData';
 import { applyFiltersAndSorting } from '../filteringAndSorting';
 import {
   inquiries,
-  paginatedInquiries,
   inquiryImages,
+  paginatedInquiries,
 } from '../mockData/inquiries';
 
 export const myDataHandlers = [
@@ -95,7 +95,7 @@ export const myDataHandlers = [
       const content = formData.get('content');
       const images = formData.getAll('images');
 
-      if (title && content && 0 <= images.length && images.length <= 3) {
+      if (title && content && images.length >= 0 && images.length <= 3) {
         return HttpResponse.json(
           { message: '문의 등록 성공' },
           { status: 200 },

--- a/src/mocks/handlers/myDataHandler.js
+++ b/src/mocks/handlers/myDataHandler.js
@@ -87,6 +87,30 @@ export const myDataHandlers = [
     }
   }),
 
+  http.post(INQUIRY_LIST_API_URL, async ({ request }) => {
+    try {
+      const formData = await request.formData();
+
+      const title = formData.get('title');
+      const content = formData.get('content');
+      const images = formData.getAll('images');
+
+      if (title && content && 0 <= images.length && images.length <= 3) {
+        return HttpResponse.json(
+          { message: '문의 등록 성공' },
+          { status: 200 },
+        );
+      }
+
+      return HttpResponse.json(
+        { message: '잘못된 요청입니다.' },
+        { status: 400 },
+      );
+    } catch (error) {
+      return HttpResponse.status(500).json({ message: `서버 오류: ${error}` });
+    }
+  }),
+
   http.get(INQUIRY_LIST_API_URL, async (req) => {
     const { request } = await req;
     const urlString = request.url.toString();


### PR DESCRIPTION
## Related issue
#82 

## Work list
- 이미지를 제목, 내용과 함께 (최대 3장) formdata에 담아서 첨부 가능하도록 했습니다
- 이미지를 첨부할 시 옆에 미리보기 이미지가 떠서 볼 수 있구요
- image preview (작성 당시) image container (목록에서 조회) 를 따로 분리했습니다

## Discussion
- 저희가 계획했던 바는 아니긴 한데, 이미지 순서 수정과 삭제가 백엔드 api에 있어서 반영 중입니다. 한 번 사용하는 레이아웃이 많이 다른 모달이라 chakra modal 사용할 거구 따로 figma에는 없습니닷.. 