### PR TITLE
Cart Page + Payment Success Page 100% finished + error fixes

### DIFF
--- a/src/app/[userId]/page.tsx
+++ b/src/app/[userId]/page.tsx
@@ -87,11 +87,7 @@ const MyPage = () => {
     queryFn: getMyData,
   });
 
-  const {
-    data: evaluates,
-    isLoading: evaluatesLoading,
-    isError: evaluatesError,
-  } = useQuery({
+  const { data: evaluates, isLoading: evaluatesLoading } = useQuery({
     queryKey: ['MyEvaluates'],
     queryFn: getMyEvaluates,
   });

--- a/src/app/cart/[meetingId]/page.tsx
+++ b/src/app/cart/[meetingId]/page.tsx
@@ -339,6 +339,14 @@ const CartPage = () => {
   //   },
   // });
 
+  // Determine footer button text based on context
+  const footerButtonText =
+    context === 'leaderAfter'
+      ? `${formatCurrency(totalPrice)} 주문하고 모임 완성하기`
+      : context === 'participant'
+        ? `${formatCurrency(totalPrice)} 주문하고 모임 참여하기`
+        : '';
+
   if (
     isLoadingMeeting ||
     isLoadingStore ||
@@ -407,7 +415,7 @@ const CartPage = () => {
       />
       <Footer
         type="button"
-        buttonText={`${formatCurrency(totalPrice)} 주문하고 모임 완성하기`}
+        buttonText={footerButtonText}
         onButtonClick={() => {
           const { individualItems, teamItems } =
             splitCartItemsByType(cartItems);

--- a/src/app/cart/[meetingId]/page.tsx
+++ b/src/app/cart/[meetingId]/page.tsx
@@ -1,19 +1,27 @@
 'use client';
 
+import axios from 'axios';
+import { useEffect, useState } from 'react';
 import { useParams, useSearchParams } from 'next/navigation';
-import router from 'next/router';
-import { useQuery } from '@tanstack/react-query';
+import { useRouter } from 'next/navigation';
+import { useQuery, useMutation } from '@tanstack/react-query';
 import { getTeamOrderInfo } from '@/services/teamOrderService';
 import { getRestaurantInfo } from '@/services/restaurantService';
+import { getMenuInfo } from '@/services/menuService';
+import { getMyData } from '@/services/myDataService';
+import { preparePayment, verifyPayment } from '@/services/paymentService'; 
 import { useOrderStore } from '@/state/orderStore';
+import { useCartStore, CartItem } from '@/state/cartStore';
 import Loading from '@/app/loading';
 import Container from '@/styles/container';
 import Header from '@/components/layout/header';
 import StoreInfo from '@/components/cart/storeInfo';
-import CartItem from '@/components/cart/cartItem';
+import CartItems from '@/components/cart/cartItems';
 import Amount from '@/components/cart/amount';
 import Footer from '@/components/layout/footer';
 import styled from 'styled-components';
+import { formatCurrency } from '@/utils/currencyFormatter';
+import { paymentFormatter } from '@/utils/paymentFormatter';
 
 const CustomContainer = styled(Container)`
   margin-top: 60px;
@@ -22,9 +30,28 @@ const CustomContainer = styled(Container)`
 `;
 
 const CartPage = () => {
-  // Hooks for navigation and params
-  const { meetingId } = useParams();
+  // State hooks for data management
+  const router = useRouter();
   const searchParams = useSearchParams();
+  const { meetingId: meetingIdParam } = useParams();
+  const storeId = searchParams.get('storeId');
+  const context = searchParams.get('context'); 
+  const { cartItems, updateQuantity } = useCartStore();
+  const { formData: { minHeadcount } } = useOrderStore(); 
+  const [ purchaseAmount, setPurchaseAmount ] = useState(0);
+  const [ minTeamPurchaseDiscount, setMinTeamPurchaseDiscount ] = useState(0);
+  const [ point, setPoint ] = useState(0);
+
+  // Convert meetingId to a number
+  const meetingId = Array.isArray(meetingIdParam) 
+  ? parseInt(meetingIdParam[0], 10) 
+  : parseInt(meetingIdParam, 10);
+
+  // Ensure meetingId is a valid number
+  if (isNaN(meetingId)) {
+    console.error("Invalid meetingId");
+    return null; // Or handle the error as appropriate
+  }
 
   // Fetch meeting data to get storeId
   const {
@@ -35,14 +62,8 @@ const CartPage = () => {
     queryKey: ['meetingInfo', meetingId],
     queryFn: () => getTeamOrderInfo(Number(meetingId)),
   });
-
-  const storeId = searchParams.get('storeId'); // Extract storeId from query params
-
-  const {
-    formData: { maxIndividualDeliveryFee },
-  } = useOrderStore();
-
-  // Fetch store data based on the storeId from meeting data
+  
+  // Fetch store information
   const {
     data: store,
     isLoading: isLoadingStore,
@@ -53,33 +74,244 @@ const CartPage = () => {
     enabled: !!meeting?.storeId,
   })
 
+  // Fetch menu information for each item in the cart
+  const menuQueries = cartItems.map(item => 
+    useQuery({
+      queryKey: ['menuInfo', item.storeId, item.menuId],
+      queryFn: () => getMenuInfo(Number(item.storeId), Number(item.menuId)),
+      enabled: !!item.menuId,
+    })
+  );
+
+  // Fetch user data to get available points
+  const { data: myData, isLoading: isLoadingMyData, isError: isErrorMyData } = useQuery({
+    queryKey: ['myData'],
+    queryFn: getMyData,
+  });
+
+  // Get delivery address
   const deliveredAddress = useOrderStore(
     (state) => state.formData.deliveredAddress,
   );
-
-  if (isLoadingMeeting || isLoadingStore) {
-    return <Loading />;
-  }
-
-  if (isErrorMeeting) {
-    return <p>Error loading meeting data</p>;
-  }
-
-  if (isErrorStore || !store) {
-    return <p>Error loading restaurant data</p>;
-  }
 
   const location =
     deliveredAddress.streetAddress || deliveredAddress.detailAddress
       ? `${deliveredAddress.streetAddress} ${deliveredAddress.detailAddress}`
       : '배송지 정보 없음';
 
-  const orderAmount = 60000;
-  const maxDeliveryFee = 5000;
-  const minCommonMenuDiscount = 3000;
-  const availablePoints = 2000;
+  // Calculate totals when cart items or other dependencies change
+  useEffect(() => {
+    const newPurchaseAmount = cartItems.reduce((total, item) => {
+      const menuData = menuQueries.find(query => query.data?.menuId === item.menuId)?.data;
+      return total + (menuData?.price || 0) * item.quantity;
+    }, 0);
+
+    setPurchaseAmount(paymentFormatter(newPurchaseAmount));
+
+    const teamPurchaseTotal = cartItems.reduce((total, item) => {
+      if (item.type === 'team') {
+        const menuData = menuQueries.find(query => query.data?.menuId === item.menuId)?.data;
+        return total + (menuData?.price || 0) * item.quantity;
+      }
+      return total;
+    }, 0);
+
+    setMinTeamPurchaseDiscount(paymentFormatter((teamPurchaseTotal / minHeadcount)) * (minHeadcount - 1));
+
+    if (myData) {
+      setPoint(myData.point);
+    }
+  }, [cartItems, menuQueries, minHeadcount, myData]);
+
+  const deliveryPrice = store?.deliveryPrice || 0;
+  const maxDeliveryFee = paymentFormatter(deliveryPrice / minHeadcount);
+
   const totalPrice =
-    orderAmount + maxDeliveryFee - minCommonMenuDiscount - availablePoints;
+    paymentFormatter(purchaseAmount + maxDeliveryFee - minTeamPurchaseDiscount - point);
+  
+  // Split cart items by types
+  const splitCartItemsByType = (cartItems: CartItem[]) => {
+    const individualItems = cartItems.filter(item => item.type === 'individual');
+    const teamItems = cartItems.filter(item => item.type === 'team');
+    
+    return { individualItems, teamItems };
+  };
+
+  // PortOne SDK initialization
+  useEffect(() => {
+    const script = document.createElement('script');
+    script.src = "https://cdn.iamport.kr/v1/iamport.js";
+    script.onload = () => {
+      window.IMP.init('imp46113628'); // Should be updated to match PortOne merchant key
+    };
+    document.body.appendChild(script);
+  }, []);
+
+  // Portone payment by mock data
+  // 1. 백엔드로 결제요청 API 보냄 -> 백엔드에서 결제 관련 정보 보내줌
+  const preparePaymentMutation = useMutation({
+    mutationFn: () => preparePayment(meetingId, `kakaopay.TC0ONETIME`, 'card', point),
+    onSuccess: (paymentData) => {
+      // 2. 프론트엔드에서 백엔드로부터 받은 정보를 바탕으로 결제 진행 (결제 완료 후 포트원uid 발급됨)
+      handlePayment(paymentData.transactionId, paymentData.name, paymentData.price, point);
+    },
+    onError: (error) => {
+      console.error("Payment preparation failed", error);
+      alert("Payment preparation failed.");
+    },
+  });
+
+  // 3. 프론트엔드에서 백엔드로 결제완료 API 요청 -> 백엔드로 결제 시 발급받은 포트원uid 보내줌
+  const verifyPaymentMutation = useMutation({
+    mutationFn: ({ meetingId, transactionId, portoneUid }: { meetingId: number; transactionId: string; portoneUid: string }) =>
+      verifyPayment(meetingId, transactionId, portoneUid),
+    onSuccess: (verifyResponse) => {
+      // 4. 백엔드에서 포트원uid로 결제 정보 조회 -> 올바르게 되었는지 프론트로 보내줌
+      if (verifyResponse.success) {
+        // 5. 결제 올바르게 되었으면 다음 단계 진행
+        router.push(`/paymentSuccess/${meetingId}?storeId=${storeId}&context=${context}`);
+      } else {
+        // 결제 올바르게 안되었으면 다시 요청
+        alert('Payment verification failed.');
+      }
+    },
+    onError: (error) => {
+      console.error("Payment verification failed", error);
+      alert("Payment verification failed.");
+    },
+  });
+
+  // 2. 프론트엔드에서 백엔드로부터 받은 정보를 바탕으로 결제 진행 (결제 완료 후 포트원uid 발급됨)
+  const handlePayment = async (
+    transactionId: string,
+    name: string,
+    price: number,
+    point: number 
+  ): Promise<any> => {
+    return new Promise((resolve, reject) => {
+      const IMP = window.IMP;
+      IMP.request_pay(
+        {
+          pg: "kakaopay.TC0ONETIME", // PG code for the test environment
+          pay_method: "card",
+          merchant_uid: transactionId,
+          name: name,
+          amount: price,
+          m_redirect_url: `${window.location.origin}/paymentSuccess/${meetingId}?storeId=${storeId}&context=${context}` 
+        },
+        (rsp) => {
+          if (rsp.success) {
+            resolve(rsp);
+            // 3. 프론트엔드에서 백엔드로 결제완료 API 요청 -> 백엔드로 결제 시 발급받은 포트원uid 보내줌
+            verifyPaymentMutation.mutate({ meetingId, transactionId, portoneUid: rsp.imp_uid });
+          } else {
+            reject(new Error(rsp.error_msg));
+          }
+        }
+      );
+    });
+  };
+  
+  // Workflow start: User submits the order and payment process begins
+  const handleSubmit = async (
+    meetingId: number, 
+    individualItems: CartItem[], 
+    teamItems: CartItem[]
+  ) => {
+    try {
+      // Handle individual purchases submission
+      if (individualItems.length > 0) {
+        const individualPayload = individualItems.map(item => ({
+          menuId: item.menuId,
+          quantity: item.quantity,
+        }));
+  
+        console.log('Submitting individual purchases:', individualPayload);
+  
+        await fetch(`/api/users/meetings/${meetingId}/individual-purchases`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify(individualPayload),
+        });
+      }
+  
+      // Handle team purchases submission
+      if (teamItems.length > 0) {
+        const teamPayload = teamItems.map(item => ({
+          menuId: item.menuId,
+          quantity: item.quantity,
+        }));
+  
+        console.log('Submitting team purchases:', teamPayload);
+  
+        await fetch(`/api/users/meetings/${meetingId}/team-purchases`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify(teamPayload),
+        });
+      }
+
+      // 1. 백엔드로 결제요청 API 보냄 -> 백엔드에서 결제 관련 정보 보내줌
+      preparePaymentMutation.mutate();
+
+    } catch (error) {
+      console.error('Failed to submit purchases:', error);
+      alert('Order submission failed.');
+    }
+  };
+
+  // // Real API
+  // // 1. 백엔드로 결제요청 API 보냄 -> 백엔드에서 결제 관련 정보 보내줌
+  // const preparePaymentMutation = useMutation({
+  //   mutationFn: () => axios.post(`/api/users/meetings/${meetingId}/purchases/payment`, {
+  //     pg: `kakaopay.TC0ONETIME`,
+  //     payMethod: 'card',
+  //     point
+  //   }).then(res => res.data),
+  //   onSuccess: (paymentData) => {
+  //     // 2. 프론트엔드에서 백엔드로부터 받은 정보를 바탕으로 결제 진행 (결제 완료 후 포트원uid 발급됨)
+  //     handlePayment(paymentData.transactionId, paymentData.name, paymentData.price);
+  //   },
+  //   onError: (error) => {
+  //     console.error("Payment preparation failed", error);
+  //     alert("Payment preparation failed.");
+  //   },
+  // });
+
+  //   // 3. 프론트엔드에서 백엔드로 결제완료 API 요청 -> 백엔드로 결제 시 발급받은 포트원uid 보내줌
+  // const verifyPaymentMutation = useMutation({
+  //   mutationFn: ({ meetingId, transactionId, portoneUid }) =>
+  //     axios.post(`/api/users/meetings/${meetingId}/purchases/payment/done`, {
+  //       transactionId,
+  //       portoneUid
+  //     }).then(res => res.data),
+  //   onSuccess: (verifyResponse) => {
+  //     // 4. 백엔드에서 포트원uid로 결제 정보 조회 -> 올바르게 되었는지 프론트로 보내줌
+  //     if (verifyResponse.success) {
+  //       // 5. 결제 올바르게 되었으면 다음 단계 진행
+  //       router.push(`/paymentSuccess/${meetingId}?storeId=${storeId}&context=${context}`);
+  //     } else {
+  //       // 결제 올바르게 안되었으면 다시 요청
+  //       alert('Payment verification failed.');
+  //     }
+  //   },
+  //   onError: (error) => {
+  //     console.error("Payment verification failed", error);
+  //     alert("Payment verification failed.");
+  //   },
+  // });
+
+  if (isLoadingMeeting || isLoadingStore || isLoadingMyData || menuQueries.some(query => query.isLoading)) {
+    return <Loading />;
+  }
+
+  if (isErrorMeeting || isErrorStore || isErrorMyData || menuQueries.some(query => query.isError)) {
+    return <p>Error loading data</p>;
+  }
 
   return (
     <>
@@ -93,23 +325,38 @@ const CartPage = () => {
             router.push(`/restaurants/${store.id}?context=leaderAfter&meetingId=${meetingId}`)
           }
         />
-        <CartItem
-          menuName="교촌오리지날(한마리)"
-          price={19000}
-          imageUrl="https://via.placeholder.com/150"
-          badgeText="공동 메뉴"
-          quantity={1}
-          storeId={String(meeting?.storeId)}
-        />
+        {cartItems.map((item: CartItem, index: number) => { 
+          const menuData = menuQueries.find(query => query.data?.menuId === item.menuId)?.data;
+          return (
+            <CartItems
+              key={item.menuId}
+              menuName={menuData?.name || 'Unknown'}
+              price={menuData?.price || 0}
+              imageUrl={menuData?.image || ''}
+              badgeText={item.type === 'individual' ? '개별메뉴' : '공동메뉴'}
+              quantity={item.quantity}
+              storeId={item.storeId}
+              showAddButton={index === cartItems.length - 1}
+              onQuantityChange={(newQuantity) => updateQuantity(item.menuId, item.storeId, newQuantity)}
+            />
+          );
+        })}
       </CustomContainer>
       <Amount
-        orderAmount={orderAmount}
-        maxDeliveryFee={maxIndividualDeliveryFee}
-        minCommonMenuDiscount={minCommonMenuDiscount}
-        availablePoints={availablePoints}
+        orderAmount={purchaseAmount}
+        maxDeliveryFee={maxDeliveryFee}
+        minTeamPurchaseDiscount={minTeamPurchaseDiscount}
+        availablePoints={point}
         totalPrice={totalPrice}
       />
-      <Footer type="button" buttonText="36,500원 주문하고 모임 완성하기" />
+      <Footer 
+        type="button" 
+        buttonText={`${formatCurrency(totalPrice)} 주문하고 모임 완성하기`}
+        onButtonClick={() => {
+          const { individualItems, teamItems } = splitCartItemsByType(cartItems);
+          handleSubmit(Number(meetingId), individualItems, teamItems);
+        }}
+      />
     </>
   );
 };

--- a/src/app/paymentSuccess/[meetingId]/page.tsx
+++ b/src/app/paymentSuccess/[meetingId]/page.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import Container from '@/styles/container';
+import Header from '@/components/layout/header';
+import SettingImage from '@/components/meetings/settingImage';
+import { BaseBtn } from '@/styles/button';
+import styled from 'styled-components';
+
+const CustomContainer = styled(Container)`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  padding: var(--spacing-lg) var(--spacing-md) 6rem;
+  gap: var(--spacing-lg);
+`;
+
+type ContextType = 'leaderAfter' | 'participant' | null;
+
+const PaymentSuccess = () => {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const context = searchParams.get('context') as ContextType; 
+  const [isHeaderTransparent, setIsHeaderTransparent] = useState(true);
+
+  const handleTitles = (context: ContextType) => {
+    switch (context) {
+      case 'leaderAfter':
+        return {
+          title: '팀 주문 성공!',
+          subTitle: '팀원들을 기다려 볼까요?',
+        };
+      case 'participant':
+        return {
+          title: '결제 성공!',
+          subTitle: '팀원들을 만나러 가볼까요?',
+        };
+      default:
+        return {
+          title: '결제 성공!',
+          subTitle: '',
+        };
+    }
+  };
+
+  const handleReturnToHome = () => {
+    router.push('/');
+  };
+
+  const handleExit = () => {
+    router.push('/');
+  };
+
+  const { title, subTitle } = handleTitles(context);
+  
+  return (
+    <>
+      <Header
+        buttonRight="exit"
+        $isTransparent={isHeaderTransparent}
+        onExit={handleExit}
+      />
+      <CustomContainer>
+        <SettingImage
+          title={title}
+          subTitle={subTitle}
+        />
+        <BaseBtn onClick={handleReturnToHome}>
+          홈 화면으로 가기
+        </BaseBtn>
+      </CustomContainer>
+    </>
+  );
+}; 
+
+export default PaymentSuccess;
+

--- a/src/app/paymentSuccess/[meetingId]/page.tsx
+++ b/src/app/paymentSuccess/[meetingId]/page.tsx
@@ -1,12 +1,14 @@
 'use client';
 
 import { useState } from 'react';
+
 import { useRouter, useSearchParams } from 'next/navigation';
+import styled from 'styled-components';
+
 import Container from '@/styles/container';
 import Header from '@/components/layout/header';
 import SettingImage from '@/components/meetings/settingImage';
 import { BaseBtn } from '@/styles/button';
-import styled from 'styled-components';
 
 const CustomContainer = styled(Container)`
   display: flex;
@@ -22,8 +24,8 @@ type ContextType = 'leaderAfter' | 'participant' | null;
 const PaymentSuccess = () => {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const context = searchParams.get('context') as ContextType; 
-  const [isHeaderTransparent, setIsHeaderTransparent] = useState(true);
+  const context = searchParams.get('context') as ContextType;
+  const [isHeaderTransparent] = useState(true);
 
   const handleTitles = (context: ContextType) => {
     switch (context) {
@@ -54,7 +56,7 @@ const PaymentSuccess = () => {
   };
 
   const { title, subTitle } = handleTitles(context);
-  
+
   return (
     <>
       <Header
@@ -63,17 +65,11 @@ const PaymentSuccess = () => {
         onExit={handleExit}
       />
       <CustomContainer>
-        <SettingImage
-          title={title}
-          subTitle={subTitle}
-        />
-        <BaseBtn onClick={handleReturnToHome}>
-          홈 화면으로 가기
-        </BaseBtn>
+        <SettingImage title={title} subTitle={subTitle} />
+        <BaseBtn onClick={handleReturnToHome}>홈 화면으로 가기</BaseBtn>
       </CustomContainer>
     </>
   );
-}; 
+};
 
 export default PaymentSuccess;
-

--- a/src/app/restaurants/[storeId]/page.tsx
+++ b/src/app/restaurants/[storeId]/page.tsx
@@ -197,6 +197,16 @@ const StorePage = () => {
     }
   };
 
+  const onModalClick1 = () => {
+    if (context === 'leaderBefore') {
+      router.push(`/teamOrderSetting/${storeId}`);
+    } else if (context === 'leaderAfter') {
+      handleAddToCart('team');
+    } else if (context === 'participant') {
+      handleAddToCart('individual');
+    }
+  };
+
   useEffect(() => {
     const contextParam = searchParams.get('context');
     setContext(contextParam);
@@ -224,8 +234,8 @@ const StorePage = () => {
           $cartQuantity={Math.round(cartQuantity)}
           iconColor={isHeaderTransparent ? 'white' : 'black'}
           $isTransparent={isHeaderTransparent}
-          meetingId={searchParams.get('meetingId') || undefined} 
-          storeId={String(storeId)}  
+          meetingId={searchParams.get('meetingId') || undefined}
+          storeId={String(storeId)}
         />
       </HeaderContainer>
       <Carousel images={store.images} ref={carouselRef} />
@@ -301,9 +311,11 @@ const StorePage = () => {
               ? context
               : undefined
           }
-          onButtonClick1={() => handleAddToCart('team')} // Call handleAddToCart with 'team' for 공통메뉴
+          onButtonClick1={onModalClick1}
           onButtonClick2={
-            context === 'leaderAfter' ? () => handleAddToCart('individual') : closeModal
+            context === 'leaderAfter'
+              ? () => handleAddToCart('individual')
+              : closeModal
           } // Call handleAddToCart with 'individual' 개별메뉴 in 'leaderAfter', otherwise closeModal
           onClose={closeModal}
         />

--- a/src/app/restaurants/[storeId]/page.tsx
+++ b/src/app/restaurants/[storeId]/page.tsx
@@ -144,9 +144,16 @@ const StorePage = () => {
   });
 
   // Function to handle adding items to the cart
-  const handleAddToCart = () => {
-    addToCart(1);
-    closeModal();
+  const handleAddToCart = (type: 'individual' | 'team') => {
+    if (selectedMenu) {
+      addToCart({
+        menuId: selectedMenu.menuId,
+        quantity: 1,
+        storeId: String(storeId),
+        type,
+      });
+      closeModal();
+    }
   };
 
   // Modal handlers
@@ -184,7 +191,7 @@ const StorePage = () => {
       if (!meetingId) {
         console.error('No meetingId found');
       } else {
-        router.push(`/cart/${meetingId}?storeId=${storeId}`);
+        router.push(`/cart/${meetingId}?storeId=${storeId}&context=${context}`);
       }
     }
   };
@@ -216,6 +223,8 @@ const StorePage = () => {
           $cartQuantity={Math.round(cartQuantity)}
           iconColor={isHeaderTransparent ? 'white' : 'black'}
           $isTransparent={isHeaderTransparent}
+          meetingId={searchParams.get('meetingId') || undefined} 
+          storeId={String(storeId)}  
         />
       </HeaderContainer>
       <Carousel images={store.images} ref={carouselRef} />
@@ -291,8 +300,10 @@ const StorePage = () => {
               ? context
               : undefined
           }
-          onButtonClick1={handleAddToCart} // Call handleAddToCart on "공동메뉴" or "개별메뉴" click
-          onButtonClick2={context === 'leaderAfter' ? handleAddToCart : closeModal} // Call handleAddToCart only in 'leaderAfter', otherwise closeModal
+          onButtonClick1={() => handleAddToCart('team')} // Call handleAddToCart with 'team' for 공통메뉴
+          onButtonClick2={
+            context === 'leaderAfter' ? () => handleAddToCart('individual') : closeModal
+          } // Call handleAddToCart with 'individual' 개별메뉴 in 'leaderAfter', otherwise closeModal
           onClose={closeModal}
         />
       )}

--- a/src/app/teamOrderSetting/[storeId]/page.tsx
+++ b/src/app/teamOrderSetting/[storeId]/page.tsx
@@ -1,7 +1,9 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import axios from 'axios';
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { v4 as uuidv4 } from 'uuid';
 
 import { useParams, useRouter } from 'next/navigation';

--- a/src/app/teamOrderSetting/[storeId]/step1.tsx
+++ b/src/app/teamOrderSetting/[storeId]/step1.tsx
@@ -19,7 +19,7 @@ import InfoBox from '@/components/common/infoBox';
 import ErrorMessage from '@/components/meetings/errorMessage';
 import DefaultAddress from '@/components/meetings/defaultAddress';
 import { Address as DaumPostcodeAddress } from 'react-daum-postcode';
-import { StoredAddress } from '@/state/orderStore'; 
+import { StoredAddress } from '@/state/orderStore';
 
 interface Step1Props {
   isPostcodeOpen: boolean;
@@ -196,7 +196,7 @@ const Step1: FC<Step1Props> = ({ isPostcodeOpen, setIsPostcodeOpen }) => {
     const formattedTime = `${hour}:${minute}`;
     setTime(updatedTime);
 
-    setPaymentAvailableAt(new Date(), updatedTime);
+    setPaymentAvailableAt(updatedTime);
 
     if (store?.openTime && store?.closeTime) {
       const [openHour, openMinute] = store.openTime.split(':').map(Number);
@@ -242,7 +242,7 @@ const Step1: FC<Step1Props> = ({ isPostcodeOpen, setIsPostcodeOpen }) => {
 
   useEffect(() => {
     if (time.hour && time.minute) {
-      setPaymentAvailableAt(new Date(), time);
+      setPaymentAvailableAt(time);
     }
   }, [time, setPaymentAvailableAt]);
 
@@ -270,7 +270,10 @@ const Step1: FC<Step1Props> = ({ isPostcodeOpen, setIsPostcodeOpen }) => {
 
   return (
     <>
-      <SettingImage />
+      <SettingImage
+        title="팀 주문 시작"
+        subTitle="팀 주문에 함께 할 모임원들을 초대해요"
+      />
       <SettingLabel text="팀 주문 방식" />
       <CustomDropdown
         options={optionsPurchaseType}

--- a/src/app/teamOrderSetting/[storeId]/step1.tsx
+++ b/src/app/teamOrderSetting/[storeId]/step1.tsx
@@ -20,7 +20,6 @@ import { CustomDropdown } from '@/components/common/dropdown';
 import InfoBox from '@/components/common/infoBox';
 import ErrorMessage from '@/components/meetings/errorMessage';
 import DefaultAddress from '@/components/meetings/defaultAddress';
-import { Address as DaumPostcodeAddress } from 'react-daum-postcode';
 import { StoredAddress } from '@/state/orderStore';
 
 interface Step1Props {
@@ -240,6 +239,7 @@ const Step1: FC<Step1Props> = ({ isPostcodeOpen, setIsPostcodeOpen }) => {
         postal: deliveredAddress.postal,
       });
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [deliveredAddress, setMetAddress]);
 
   useEffect(() => {

--- a/src/app/teamOrderSetting/[storeId]/step2.tsx
+++ b/src/app/teamOrderSetting/[storeId]/step2.tsx
@@ -13,7 +13,7 @@ import SettingLabel from '@/components/meetings/settingLabel';
 import SettingHeadcount from '@/components/meetings/settingHeadcount';
 import SettingDescription from '@/components/meetings/settingDescription';
 import DeliveryFees from '@/components/meetings/deliveryFee';
-import { paymentFormatter } from '@/utils/paymentFormatter'; 
+import { paymentFormatter } from '@/utils/paymentFormatter';
 
 const Step2 = () => {
   // State management using the order store
@@ -46,10 +46,6 @@ const Step2 = () => {
     const isActive = minHeadcount > 0 && maxHeadcount >= minHeadcount;
     setButtonActive(isActive);
   }, [minHeadcount, maxHeadcount, setButtonActive]);
-
-  if (!store) {
-    return null;
-  }
 
   // Effect to set max individual delivery fee
   useEffect(() => {

--- a/src/app/teamOrderSetting/[storeId]/step2.tsx
+++ b/src/app/teamOrderSetting/[storeId]/step2.tsx
@@ -12,6 +12,7 @@ import SettingLabel from '@/components/meetings/settingLabel';
 import SettingHeadcount from '@/components/meetings/settingHeadcount';
 import SettingDescription from '@/components/meetings/settingDescription';
 import DeliveryFees from '@/components/meetings/deliveryFee';
+import { paymentFormatter } from '@/utils/paymentFormatter'; 
 
 const Step2 = () => {
   // State management using the order store
@@ -52,10 +53,8 @@ const Step2 = () => {
   // Effect to set max individual delivery fee
   useEffect(() => {
     if (store) {
-      const roundToNearestTen = (num: number) => Math.floor(num / 10) * 10;
-
       const deliveryPrice = store.deliveryPrice || 0;
-      const maxFee = roundToNearestTen(
+      const maxFee = paymentFormatter(
         deliveryPrice / Math.max(minHeadcount, 1),
       );
 
@@ -68,17 +67,13 @@ const Step2 = () => {
   }
 
   // Calculate delivery fees
-  const roundToNearestTen = (num: number) => {
-    return Math.floor(num / 10) * 10;
-  };
-
   const deliveryPrice = store.deliveryPrice || 0;
 
-  const maxIndividualDeliveryFee = roundToNearestTen(
+  const maxIndividualDeliveryFee = paymentFormatter(
     store.deliveryPrice / Math.max(minHeadcount, 1),
   );
 
-  const minIndividualDeliveryFee = roundToNearestTen(
+  const minIndividualDeliveryFee = paymentFormatter(
     store.deliveryPrice / Math.max(maxHeadcount, 1),
   );
 

--- a/src/components/cart/amount.tsx
+++ b/src/components/cart/amount.tsx
@@ -5,7 +5,7 @@ import { formatCurrency } from '@/utils/currencyFormatter';
 interface AmountProps {
   orderAmount: number;
   maxDeliveryFee: number;
-  minCommonMenuDiscount: number;
+  minTeamPurchaseDiscount: number;
   availablePoints: number;
   totalPrice: number;
 }
@@ -80,7 +80,7 @@ const Description = styled.p`
 const Amount: React.FC<AmountProps> = ({
   orderAmount,
   maxDeliveryFee,
-  minCommonMenuDiscount,
+  minTeamPurchaseDiscount,
   availablePoints,
   totalPrice,
 }) => (
@@ -97,7 +97,7 @@ const Amount: React.FC<AmountProps> = ({
       </MenuItemRow>
       <MenuItemRow>
         <MenuItemName>공통 메뉴 최소 할인</MenuItemName>
-        <MenuItemPrice>{formatCurrency(minCommonMenuDiscount)}</MenuItemPrice>
+        <MenuItemPrice>{formatCurrency(minTeamPurchaseDiscount)}</MenuItemPrice>
       </MenuItemRow>
       <MenuItemRow>
         <MenuItemName>사용 사능한 포인트</MenuItemName>

--- a/src/components/cart/cartItems.tsx
+++ b/src/components/cart/cartItems.tsx
@@ -15,7 +15,8 @@ interface CartItemProps {
   imageUrl: string;
   badgeText: string;
   quantity: number;
-  storeId: string;
+  storeId: number;
+  meetingId: number;
   showAddButton?: boolean;
   onQuantityChange?: (newQuantity: number) => void;
 }
@@ -86,6 +87,7 @@ export default function CartItems({
   badgeText,
   quantity: initialQuantity,
   storeId,
+  meetingId,
   showAddButton = false,
   onQuantityChange,
 }: CartItemProps) {
@@ -104,7 +106,9 @@ export default function CartItems({
   }, [quantity, onQuantityChange]);
 
   const handleAddItem = () => {
-    router.push(`/restaurants/${storeId}?context=leaderAfter`);
+    router.push(
+      `/restaurants/${storeId}?context=leaderAfter&meetingId=${meetingId}`,
+    );
   };
 
   return (

--- a/src/components/cart/cartItems.tsx
+++ b/src/components/cart/cartItems.tsx
@@ -15,6 +15,8 @@ interface CartItemProps {
   badgeText: string;
   quantity: number;
   storeId: string;
+  showAddButton?: boolean;
+  onQuantityChange?: (newQuantity: number) => void;
 }
 
 const Container = styled.div`
@@ -76,13 +78,15 @@ const QuantityContainer = styled.div`
   align-items: center;
 `;
 
-export default function CartItem({
+export default function CartItems({
   menuName,
   price,
   imageUrl,
   badgeText,
   quantity: initialQuantity,
   storeId,
+  showAddButton = false,
+  onQuantityChange,
 }: CartItemProps) {
   const [quantity, setQuantity] = useState(initialQuantity);
   const [totalPrice, setTotalPrice] = useState(price * quantity);
@@ -91,6 +95,12 @@ export default function CartItem({
   useEffect(() => {
     setTotalPrice(price * quantity);
   }, [price, quantity]);
+
+  useEffect(() => {
+    if (onQuantityChange) {
+      onQuantityChange(quantity);
+    }
+  }, [quantity, onQuantityChange]);
 
   const handleAddItem = () => {
     router.push(`/restaurants/${storeId}?context=leaderAfter`);
@@ -128,29 +138,31 @@ export default function CartItem({
           borderColor: 'var(--gray200)',
         }}
       />
-      <Button
-        onClick={handleAddItem}
-        sx={{
-          backgroundColor: 'transparent',
-          color: 'var(--text)',
-          height: 'auto',
-          margin: 'none',
-          padding: 'none',
-          fontSize: 'var(--font-size-sm)',
-          fontWeight: 'var(--font-regular)',
-          _hover: {
+      {showAddButton && (
+        <Button
+          onClick={handleAddItem}
+          sx={{
             backgroundColor: 'transparent',
-          },
-          _active: {
-            backgroundColor: 'transparent',
-          },
-          _focus: {
-            boxShadow: 'none',
-          },
-        }}
-      >
-        + 메뉴 추가
-      </Button>
+            color: 'var(--text)',
+            height: 'auto',
+            margin: 'none',
+            padding: 'none',
+            fontSize: 'var(--font-size-sm)',
+            fontWeight: 'var(--font-regular)',
+            _hover: {
+              backgroundColor: 'transparent',
+            },
+            _active: {
+              backgroundColor: 'transparent',
+            },
+            _focus: {
+              boxShadow: 'none',
+            },
+          }}
+        >
+          + 메뉴 추가
+        </Button>
+      )}
     </Container>
   );
 }

--- a/src/components/cart/storeInfo.tsx
+++ b/src/components/cart/storeInfo.tsx
@@ -30,6 +30,7 @@ const ArrowButton = styled.button`
   border: none;
   cursor: pointer;
   font-size: var(--font-size-sm);
+  font-weight: var(--font-semi-bold);
   color: var(--gray400);
   padding-bottom: var(--spacing-xs);
 `;

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -68,7 +68,7 @@ const CartQuantityCircle = styled.div`
   right: -8px;
   width: 20px;
   height: 20px;
-  background-color: red;
+  background-color: var(--primary);
   color: white;
   border-radius: 50%;
   display: flex;
@@ -80,6 +80,8 @@ const CartQuantityCircle = styled.div`
 
 const CartIconContainer = styled.div`
   position: relative;
+  display: flex;
+  align-items: center;
 `;
 
 interface HeaderProps {
@@ -155,6 +157,11 @@ const Header: React.FC<HeaderProps> = ({
         </Flex>
         <Flex $side="center">{text}</Flex>
         <Flex $side="right">
+          {buttonRight && (
+            <button type="button" onClick={handleRightButtonClick}>
+              {Icons[buttonRight](iconColor)}
+            </button>
+          )}
           {buttonRightSecondary && (
             <CartIconContainer>
               <button type="button" onClick={handleRightSecondaryButtonClick}>

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -96,6 +96,8 @@ interface HeaderProps {
   onClosePostcodeModal?: () => void;
   $isTransparent?: boolean;
   $cartQuantity?: number;
+  meetingId?: string;
+  storeId?: string;
 }
 
 const Header: React.FC<HeaderProps> = ({
@@ -112,6 +114,8 @@ const Header: React.FC<HeaderProps> = ({
   onClosePostcodeModal,
   $isTransparent = false,
   $cartQuantity = 0,
+  meetingId,
+  storeId,
 }) => {
   const router = useRouter();
   const { isOpen, onToggle } = useDisclosure();
@@ -140,7 +144,11 @@ const Header: React.FC<HeaderProps> = ({
 
   const handleRightSecondaryButtonClick = () => {
     if (buttonRightSecondary === 'cart') {
-      router.push('/cart');
+      if (meetingId && storeId) {
+        router.push(`/cart/${meetingId}?storeId=${storeId}`);
+      } else {
+        router.push('/cart');
+      }
     }
   };
 

--- a/src/components/meetings/settingAddress.tsx
+++ b/src/components/meetings/settingAddress.tsx
@@ -50,14 +50,13 @@ const AddressBtn = styled.button<{ $hasAddress: boolean }>`
   text-align: left;
 `;
 
-const PostcodeWrapper = styled.div<{ $isOpen: boolean }>`
+const PostcodeWrapper = styled.div`
   position: fixed;
   top: 60px;
   left: 0;
   width: 100%;
   height: 100vh;
   background: rgba(0, 0, 0, 0.5);
-  display: ${({ $isOpen }) => ($isOpen ? 'flex' : 'none')};
   align-items: center;
   justify-content: center;
   z-index: 1000;
@@ -105,10 +104,14 @@ const SettingAddress: FC<SettingAddressProps> = ({
     });
   };
 
+  const openPostcodeSearch = () => {
+    setIsPostcodeOpen(true);
+  };
+
   return (
     <div>
       <Flex>
-        <Wrapper onClick={() => setIsPostcodeOpen(true)}>
+        <Wrapper onClick={openPostcodeSearch}>
           <AddressBtn $hasAddress={!!streetAddress}>
             {streetAddress || '우편번호 검색'}
           </AddressBtn>
@@ -127,12 +130,14 @@ const SettingAddress: FC<SettingAddressProps> = ({
           위치로 설정해주세요.
         </Caption>
       </Flex>
-      <PostcodeWrapper $isOpen={isPostcodeOpen}>
-        <DaumPostcodeEmbed
-          onComplete={handleComplete}
-          style={{ width: '100%', height: '100%' }}
-        />
-      </PostcodeWrapper>
+      {isPostcodeOpen && (
+        <PostcodeWrapper>
+          <DaumPostcodeEmbed
+            onComplete={handleComplete}
+            style={{ width: '100%', height: '100%' }}
+          />
+        </PostcodeWrapper>
+      )}
     </div>
   );
 };

--- a/src/components/meetings/settingImage.tsx
+++ b/src/components/meetings/settingImage.tsx
@@ -35,10 +35,15 @@ const ImageWrapper = styled.div`
   background-color: transparent;
 `;
 
-const SettingImage = () => (
+interface SettingImageProps {
+  title: string;
+  subTitle: string;
+}
+
+const SettingImage: React.FC<SettingImageProps> = ({ title, subTitle }) => (
   <Container>
-    <Title>팀 주문 시작</Title>
-    <SubTitle>팀 주문에 함께 할 모임원들을 초대해요</SubTitle>
+    <Title>{title}</Title>
+    <SubTitle>{subTitle}</SubTitle>
     <ImageWrapper>
       <Image
         src="/settingImage.png"

--- a/src/components/stores/carousel.tsx
+++ b/src/components/stores/carousel.tsx
@@ -169,4 +169,6 @@ const Carousel = forwardRef<HTMLDivElement, CarouselProps>(
   },
 );
 
+Carousel.displayName = 'Carousel';
+
 export default Carousel;

--- a/src/mocks/handler.js
+++ b/src/mocks/handler.js
@@ -5,6 +5,7 @@ import { teamPurchaseHandlers } from './handlers/teamPurchaseHandlers';
 import { individualPurchaseHandlers } from './handlers/individualPurchaseHandlers';
 import { myDataHandlers } from './handlers/myDataHandler';
 import { authHandlers } from './handlers/authHandlers';
+import { paymentHandlers } from './handlers/paymentHandlers';
 
 export const handler = [
   ...restaurantHandlers,
@@ -14,4 +15,5 @@ export const handler = [
   ...individualPurchaseHandlers,
   ...myDataHandlers,
   ...authHandlers,
+  ...paymentHandlers,
 ];

--- a/src/mocks/handlers/paymentHandlers.js
+++ b/src/mocks/handlers/paymentHandlers.js
@@ -1,5 +1,6 @@
 import { http, HttpResponse } from 'msw';
-import { paymentResponse, paymentDoneResponse } from '@/mocks/mockData/payment';
+
+import { paymentDoneResponse, paymentResponse } from '@/mocks/mockData/payment';
 
 export const paymentHandlers = [
   http.post('/api/users/meetings/:meetingId/purchases/payment', () => {

--- a/src/mocks/handlers/paymentHandlers.js
+++ b/src/mocks/handlers/paymentHandlers.js
@@ -1,0 +1,24 @@
+import { http, HttpResponse } from 'msw';
+import { paymentResponse, paymentDoneResponse } from '@/mocks/mockData/payment';
+
+export const paymentHandlers = [
+  http.post('/api/users/meetings/:meetingId/purchases/payment', () => {
+    try {
+      return HttpResponse.json(paymentResponse);
+    } catch (error) {
+      return HttpResponse.status(500).json({
+        message: `Failed to prepare payment: ${error}`,
+      });
+    }
+  }),
+
+  http.post('/api/users/meetings/:meetingId/purchases/payment/done', () => {
+    try {
+      return HttpResponse.json(paymentDoneResponse);
+    } catch (error) {
+      return HttpResponse.status(500).json({
+        message: `Failed to verify payment: ${error}`,
+      });
+    }
+  }),
+];

--- a/src/mocks/mockData/payment.ts
+++ b/src/mocks/mockData/payment.ts
@@ -1,0 +1,10 @@
+export const paymentResponse = {
+  transactionId: 'mockTransactionId123',
+  name: 'Mock Product Name',
+  price: 10000,
+};
+
+export const paymentDoneResponse = {
+  transactionId: 'mockTransactionId123',
+  success: true,
+};

--- a/src/services/paymentService.ts
+++ b/src/services/paymentService.ts
@@ -1,8 +1,11 @@
-import { PaymentResponse, PaymentDoneResponse } from '@/types/paymentTypes';
 import { apiClient } from './apiClient';
 
-const PAYMENT_PREPARE_API_URL = '/api/users/meetings/{meetingId}/purchases/payment';
-const PAYMENT_DONE_API_URL = '/api/users/meetings/{meetingId}/purchases/payment/done';
+import { PaymentDoneResponse, PaymentResponse } from '@/types/paymentTypes';
+
+const PAYMENT_PREPARE_API_URL =
+  '/api/users/meetings/{meetingId}/purchases/payment';
+const PAYMENT_DONE_API_URL =
+  '/api/users/meetings/{meetingId}/purchases/payment/done';
 
 // Function to prepare the payment
 export const preparePayment = async (
@@ -12,7 +15,10 @@ export const preparePayment = async (
   point: number,
 ): Promise<PaymentResponse> => {
   try {
-    const url = PAYMENT_PREPARE_API_URL.replace('{meetingId}', meetingId.toString());
+    const url = PAYMENT_PREPARE_API_URL.replace(
+      '{meetingId}',
+      meetingId.toString(),
+    );
     const response = await apiClient.post<PaymentResponse>(url, {
       pg,
       payMethod,
@@ -21,7 +27,9 @@ export const preparePayment = async (
     return response.data;
   } catch (error) {
     console.error('Error preparing payment:', error);
-    throw new Error('결제를 준비하는 데 문제가 발생했습니다. 잠시 후 다시 시도해 주세요.');
+    throw new Error(
+      '결제를 준비하는 데 문제가 발생했습니다. 잠시 후 다시 시도해 주세요.',
+    );
   }
 };
 
@@ -32,7 +40,10 @@ export const verifyPayment = async (
   portoneUid: string,
 ): Promise<PaymentDoneResponse> => {
   try {
-    const url = PAYMENT_DONE_API_URL.replace('{meetingId}', meetingId.toString());
+    const url = PAYMENT_DONE_API_URL.replace(
+      '{meetingId}',
+      meetingId.toString(),
+    );
     const response = await apiClient.post<PaymentDoneResponse>(url, {
       transactionId,
       portoneUid,
@@ -40,6 +51,8 @@ export const verifyPayment = async (
     return response.data;
   } catch (error) {
     console.error('Error verifying payment:', error);
-    throw new Error('결제 검증에 문제가 발생했습니다. 잠시 후 다시 시도해 주세요.');
+    throw new Error(
+      '결제 검증에 문제가 발생했습니다. 잠시 후 다시 시도해 주세요.',
+    );
   }
 };

--- a/src/services/paymentService.ts
+++ b/src/services/paymentService.ts
@@ -1,0 +1,45 @@
+import { PaymentResponse, PaymentDoneResponse } from '@/types/paymentTypes';
+import { apiClient } from './apiClient';
+
+const PAYMENT_PREPARE_API_URL = '/api/users/meetings/{meetingId}/purchases/payment';
+const PAYMENT_DONE_API_URL = '/api/users/meetings/{meetingId}/purchases/payment/done';
+
+// Function to prepare the payment
+export const preparePayment = async (
+  meetingId: number,
+  pg: string,
+  payMethod: string,
+  point: number,
+): Promise<PaymentResponse> => {
+  try {
+    const url = PAYMENT_PREPARE_API_URL.replace('{meetingId}', meetingId.toString());
+    const response = await apiClient.post<PaymentResponse>(url, {
+      pg,
+      payMethod,
+      point,
+    });
+    return response.data;
+  } catch (error) {
+    console.error('Error preparing payment:', error);
+    throw new Error('결제를 준비하는 데 문제가 발생했습니다. 잠시 후 다시 시도해 주세요.');
+  }
+};
+
+// Function to verify the payment after it is completed
+export const verifyPayment = async (
+  meetingId: number,
+  transactionId: string,
+  portoneUid: string,
+): Promise<PaymentDoneResponse> => {
+  try {
+    const url = PAYMENT_DONE_API_URL.replace('{meetingId}', meetingId.toString());
+    const response = await apiClient.post<PaymentDoneResponse>(url, {
+      transactionId,
+      portoneUid,
+    });
+    return response.data;
+  } catch (error) {
+    console.error('Error verifying payment:', error);
+    throw new Error('결제 검증에 문제가 발생했습니다. 잠시 후 다시 시도해 주세요.');
+  }
+};

--- a/src/state/cartStore.ts
+++ b/src/state/cartStore.ts
@@ -9,7 +9,7 @@ export interface CartItem {
 
 interface CartState {
   cartItems: CartItem[];
-  cartQuantity: number; 
+  cartQuantity: number;
   addToCart: (item: CartItem) => void;
   updateQuantity: (menuId: number, storeId: string, quantity: number) => void;
   resetCart: () => void;
@@ -21,43 +21,50 @@ export const useCartStore = create<CartState>((set) => ({
   addToCart: (newItem: CartItem) =>
     set((state) => {
       const existingItem = state.cartItems.find(
-        (item) => item.menuId === newItem.menuId && item.storeId === newItem.storeId
+        (item) =>
+          item.menuId === newItem.menuId && item.storeId === newItem.storeId,
       );
       let updatedItems;
       if (existingItem) {
         updatedItems = state.cartItems.map((item) =>
           item.menuId === newItem.menuId && item.storeId === newItem.storeId
             ? { ...item, quantity: item.quantity + newItem.quantity }
-            : item
+            : item,
         );
       } else {
         updatedItems = [...state.cartItems, newItem];
       }
       return {
         cartItems: updatedItems,
-        cartQuantity: updatedItems.reduce((acc, item) => acc + item.quantity, 0),
+        cartQuantity: updatedItems.reduce(
+          (acc, item) => acc + item.quantity,
+          0,
+        ),
       };
     }),
   updateQuantity: (menuId: number, storeId: string, quantity: number) =>
     set((state) => {
       const existingItem = state.cartItems.find(
-        (item) => item.menuId === menuId && item.storeId === storeId
+        (item) => item.menuId === menuId && item.storeId === storeId,
       );
-  
+
       // Prevent unnecessary updates
       if (existingItem && existingItem.quantity === quantity) {
         return state;
       }
-  
+
       const updatedItems = state.cartItems.map((item) =>
         item.menuId === menuId && item.storeId === storeId
           ? { ...item, quantity }
-          : item
+          : item,
       );
-  
+
       return {
         cartItems: updatedItems,
-        cartQuantity: updatedItems.reduce((acc, item) => acc + item.quantity, 0),
+        cartQuantity: updatedItems.reduce(
+          (acc, item) => acc + item.quantity,
+          0,
+        ),
       };
     }),
   resetCart: () =>

--- a/src/state/cartStore.ts
+++ b/src/state/cartStore.ts
@@ -1,17 +1,68 @@
 import { create } from 'zustand';
 
+export interface CartItem {
+  menuId: number;
+  quantity: number;
+  type: 'individual' | 'team'; // 'individual' for 공통메뉴, 'team' for 개별메뉴
+  storeId: string;
+}
+
 interface CartState {
-  cartQuantity: number;
-  addToCart: (quantity: number) => void;
+  cartItems: CartItem[];
+  cartQuantity: number; 
+  addToCart: (item: CartItem) => void;
+  updateQuantity: (menuId: number, storeId: string, quantity: number) => void;
   resetCart: () => void;
 }
 
 export const useCartStore = create<CartState>((set) => ({
+  cartItems: [],
   cartQuantity: 0,
-  addToCart: (quantity: number) =>
-    set((state) => ({ cartQuantity: state.cartQuantity + quantity })),
+  addToCart: (newItem: CartItem) =>
+    set((state) => {
+      const existingItem = state.cartItems.find(
+        (item) => item.menuId === newItem.menuId && item.storeId === newItem.storeId
+      );
+      let updatedItems;
+      if (existingItem) {
+        updatedItems = state.cartItems.map((item) =>
+          item.menuId === newItem.menuId && item.storeId === newItem.storeId
+            ? { ...item, quantity: item.quantity + newItem.quantity }
+            : item
+        );
+      } else {
+        updatedItems = [...state.cartItems, newItem];
+      }
+      return {
+        cartItems: updatedItems,
+        cartQuantity: updatedItems.reduce((acc, item) => acc + item.quantity, 0),
+      };
+    }),
+  updateQuantity: (menuId: number, storeId: string, quantity: number) =>
+    set((state) => {
+      const existingItem = state.cartItems.find(
+        (item) => item.menuId === menuId && item.storeId === storeId
+      );
+  
+      // Prevent unnecessary updates
+      if (existingItem && existingItem.quantity === quantity) {
+        return state;
+      }
+  
+      const updatedItems = state.cartItems.map((item) =>
+        item.menuId === menuId && item.storeId === storeId
+          ? { ...item, quantity }
+          : item
+      );
+  
+      return {
+        cartItems: updatedItems,
+        cartQuantity: updatedItems.reduce((acc, item) => acc + item.quantity, 0),
+      };
+    }),
   resetCart: () =>
     set({
+      cartItems: [],
       cartQuantity: 0,
     }),
 }));

--- a/src/state/orderStore.ts
+++ b/src/state/orderStore.ts
@@ -103,34 +103,34 @@ export const useOrderStore = create<OrderStore>((set) => ({
         isEarlyPaymentAvailable: state.formData.orderType === '바로 주문',
       },
     })),
-    setPaymentAvailableAt: (time: Time) => {
-      const currentDate = new Date();
-    
-      let hour = parseInt(time.hour, 10);
-      if (time.amPm === '오후' && hour !== 12) {
-        hour += 12;
-      } else if (time.amPm === '오전' && hour === 12) {
-        hour = 0;
-      }
-    
-      currentDate.setHours(hour);
-      currentDate.setMinutes(parseInt(time.minute, 10));
-      currentDate.setSeconds(0);
-      currentDate.setMilliseconds(0);
-    
-      if (isNaN(currentDate.getTime())) {
-        console.error('Invalid time value');
-        return;
-      }
-    
-      const isoDate = new Date(
-        currentDate.getTime() - currentDate.getTimezoneOffset() * 60000
-      ).toISOString();
-    
-      set((state) => ({
-        formData: { ...state.formData, paymentAvailableAt: isoDate },
-      }));
-    },
+  setPaymentAvailableAt: (time: Time) => {
+    const currentDate = new Date();
+
+    let hour = parseInt(time.hour, 10);
+    if (time.amPm === '오후' && hour !== 12) {
+      hour += 12;
+    } else if (time.amPm === '오전' && hour === 12) {
+      hour = 0;
+    }
+
+    currentDate.setHours(hour);
+    currentDate.setMinutes(parseInt(time.minute, 10));
+    currentDate.setSeconds(0);
+    currentDate.setMilliseconds(0);
+
+    if (isNaN(currentDate.getTime())) {
+      console.error('Invalid time value');
+      return;
+    }
+
+    const isoDate = new Date(
+      currentDate.getTime() - currentDate.getTimezoneOffset() * 60000,
+    ).toISOString();
+
+    set((state) => ({
+      formData: { ...state.formData, paymentAvailableAt: isoDate },
+    }));
+  },
   setTime: (newTime) =>
     set((state) => ({
       formData: {

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -1,0 +1,6 @@
+interface Window {
+  IMP: {
+    init(merchantIdentifier: string): void;
+    request_pay(paymentData: any, callback: (response: any) => void): void;
+  };
+}

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -1,6 +1,20 @@
 interface Window {
   IMP: {
     init(merchantIdentifier: string): void;
-    request_pay(paymentData: any, callback: (response: any) => void): void;
+    request_pay(
+      params: {
+        pg: string;
+        pay_method: string;
+        merchant_uid: string;
+        name: string;
+        amount: number;
+        m_redirect_url: string;
+      },
+      callback: (response: {
+        success: boolean;
+        imp_uid: string;
+        error_msg?: string;
+      }) => void,
+    ): void;
   };
 }

--- a/src/types/paymentTypes.ts
+++ b/src/types/paymentTypes.ts
@@ -1,0 +1,10 @@
+export interface PaymentResponse {
+  transactionId: string;
+  name: string;
+  price: number;
+}
+
+export interface PaymentDoneResponse {
+  transactionId: string;
+  success: boolean;
+}

--- a/src/utils/paymentFormatter.ts
+++ b/src/utils/paymentFormatter.ts
@@ -1,0 +1,3 @@
+export const paymentFormatter = (num: number): number => {
+  return Math.floor(num / 10) * 10;
+};


### PR DESCRIPTION
## Related issue
`#106` 

## Result
모임장인 경우:
https://github.com/user-attachments/assets/6c87007f-6a12-497c-a943-efba0fc9b894

모임원인 경우:
https://github.com/user-attachments/assets/ab693090-1ab4-4216-924f-7f235ddbf1e9

## Work list
- 결제 직전 장바구니 + 결제 성공페이지 + PortOne 카카오페이 결제 구현완료했습니다
- router 푸시로 context를 계속 넘기는 식으로 구현해서, 같은 화면에 모임장인지 모임원인지에 때라 다르게 구현했습니다 (예, 모임장만 공동메뉴를 담을 수 있다, footer에 있는 문구 다르다 등등)

## Discussion
- 팀 주문 setting의 주소 설정 부분 수정했는데, 제가 이 페이지에 로직 좀 복잡해서 채원님 만드신 걸 바로 가져와서 사용하면 건드리는 게 많아서 오류 다시 고쳐야 돼서 그냥 노션에 올려주신 방법을 참고해서 문제 해결했습니다.
- PortOne 카카오페이 완성까지 진행하려면 모바일에서 해야 돼서 그 부분을 배포한 상태에서 확인해야 되는데, 지금 development로 배포해도 mock data 안나와서 왜 그런지 모르겠네요..
